### PR TITLE
Use object shorthand for properties

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -24,7 +24,7 @@ function abstractPersistence (opts) {
     const mq = buildEmitter()
     const broker = {
       id: 'broker-42',
-      mq: mq,
+      mq,
       publish: mq.emit.bind(mq),
       subscribe: mq.on.bind(mq),
       unsubscribe: mq.removeListener.bind(mq),
@@ -505,8 +505,8 @@ function abstractPersistence (opts) {
   testInstance('replace subscriptions', function (t, instance) {
     const client = { id: 'abcde' }
     const topic = 'hello'
-    const sub = { topic: topic }
-    const subByTopic = { clientId: client.id, topic: topic }
+    const sub = { topic }
+    const subByTopic = { clientId: client.id, topic }
 
     function check (qos, cb) {
       sub.qos = subByTopic.qos = qos
@@ -551,18 +551,18 @@ function abstractPersistence (opts) {
     const client = { id: 'abcde' }
     const topic = 'hello'
     const subs = [
-      { topic: topic, qos: 0 },
-      { topic: topic, qos: 1 },
-      { topic: topic, qos: 2 },
-      { topic: topic, qos: 1 },
-      { topic: topic, qos: 0 }
+      { topic, qos: 0 },
+      { topic, qos: 1 },
+      { topic, qos: 2 },
+      { topic, qos: 1 },
+      { topic, qos: 0 }
     ]
     instance.addSubscriptions(client, subs, function (err, reClient) {
       t.equal(reClient, client, 'client must be the same')
       t.error(err, 'no error')
       instance.subscriptionsByClient(client, function (err, subsForClient, client) {
         t.error(err, 'no error')
-        t.deepEqual(subsForClient, [{ topic: topic, qos: 0 }])
+        t.deepEqual(subsForClient, [{ topic, qos: 0 }])
         instance.subscriptionsByTopic(topic, function (err, subsForTopic) {
           t.error(err, 'no error')
           t.deepEqual(subsForTopic, [])
@@ -706,7 +706,7 @@ function abstractPersistence (opts) {
     const client = { id: 'abcde' }
     const topic = 'hello'
     const subs = [{
-      topic: topic,
+      topic,
       qos: 1
     }]
 
@@ -731,7 +731,7 @@ function abstractPersistence (opts) {
     const client = { id: 'abcde' }
     const topic = 'hello'
     const subs = [{
-      topic: topic,
+      topic,
       qos: 0
     }]
 

--- a/persistence.js
+++ b/persistence.js
@@ -113,7 +113,7 @@ MemoryPersistence.prototype.removeSubscriptions = function (client, subs, cb) {
       const qos = stored.get(topic)
       if (qos !== undefined) {
         if (qos > 0) {
-          trie.remove(topic, { clientId: client.id, topic: topic })
+          trie.remove(topic, { clientId: client.id, topic })
         }
         stored.delete(topic)
       }
@@ -156,7 +156,7 @@ MemoryPersistence.prototype.cleanSubscriptions = function (client, cb) {
     for (const topicAndQos of stored) {
       if (topicAndQos[1] > 0) {
         const topic = topicAndQos[0]
-        trie.remove(topic, { clientId: client.id, topic: topic })
+        trie.remove(topic, { clientId: client.id, topic })
       }
     }
 

--- a/test.js
+++ b/test.js
@@ -5,6 +5,6 @@ const memory = require('./')
 const abs = require('./abstract')
 
 abs({
-  test: test,
+  test,
   persistence: memory
 })


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This syntax is supported in Node.js 4.x and up, and this module declares compatibility with Node.js 10.x and up ✅ 