### PR TITLE
fix: Abstract topic list concurrency failing due to result ordering

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -767,6 +767,7 @@ function abstractPersistence (opts) {
       if (!--calls) {
         instance.subscriptionsByClient(client, function (err, resubs) {
           t.notOk(err, 'no error')
+          resubs.sort((a, b) => b.topic.localeCompare(b.topic, 'en'))
           t.deepEqual(resubs, [subs1[0], subs2[0]])
           instance.destroy(t.end.bind(t))
         })


### PR DESCRIPTION
See [aedes-persistence-mongodb#65](https://github.com/moscajs/aedes-persistence-mongodb/pull/65)