### PR TITLE
Bugfix/pl 1797 aedes persistence redis scalability fix

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -275,10 +275,7 @@ function abstractPersistence (opts) {
     const subs = [{
       topic: 'hello',
       qos: 1
-    }, {
-      topic: 'hello/#',
-      qos: 1
-    }, {
+    },{
       topic: 'matteo',
       qos: 1
     }]
@@ -288,10 +285,6 @@ function abstractPersistence (opts) {
       instance.subscriptionsByTopic('hello', function (err, resubs) {
         t.notOk(err, 'no error')
         t.deepEqual(resubs, [{
-          clientId: client.id,
-          topic: 'hello/#',
-          qos: 1
-        }, {
           clientId: client.id,
           topic: 'hello',
           qos: 1
@@ -376,9 +369,6 @@ function abstractPersistence (opts) {
       topic: 'hello',
       qos: 0
     }, {
-      topic: 'hello/#',
-      qos: 1
-    }, {
       topic: 'matteo',
       qos: 1
     }]
@@ -390,11 +380,7 @@ function abstractPersistence (opts) {
         t.deepEqual(resubs, subs)
         instance.subscriptionsByTopic('hello', function (err, resubs2) {
           t.notOk(err, 'no error')
-          t.deepEqual(resubs2, [{
-            clientId: client.id,
-            topic: 'hello/#',
-            qos: 1
-          }])
+          t.deepEqual(resubs2, [])
           instance.destroy(t.end.bind(t))
         })
       })

--- a/abstract.js
+++ b/abstract.js
@@ -112,18 +112,6 @@ function abstractPersistence (opts) {
     matchRetainedWithPattern(t, 'hello/world')
   })
 
-  // test('look up retained messages with a # pattern', function (t) {
-  //   matchRetainedWithPattern(t, '#')
-  // })
-
-  // test('look up retained messages with a hello/world/# pattern', function (t) {
-  //   matchRetainedWithPattern(t, 'hello/world/#')
-  // })
-
-  // test('look up retained messages with a + pattern', function (t) {
-  //   matchRetainedWithPattern(t, 'hello/+')
-  // })
-
   test('look up retained messages with multiple patterns', function (t) {
     matchRetainedWithPattern(t, ['hello/world', 'other/hello'])
   })

--- a/abstract.js
+++ b/abstract.js
@@ -112,20 +112,20 @@ function abstractPersistence (opts) {
     matchRetainedWithPattern(t, 'hello/world')
   })
 
-  test('look up retained messages with a # pattern', function (t) {
-    matchRetainedWithPattern(t, '#')
-  })
+  // test('look up retained messages with a # pattern', function (t) {
+  //   matchRetainedWithPattern(t, '#')
+  // })
 
-  test('look up retained messages with a hello/world/# pattern', function (t) {
-    matchRetainedWithPattern(t, 'hello/world/#')
-  })
+  // test('look up retained messages with a hello/world/# pattern', function (t) {
+  //   matchRetainedWithPattern(t, 'hello/world/#')
+  // })
 
-  test('look up retained messages with a + pattern', function (t) {
-    matchRetainedWithPattern(t, 'hello/+')
-  })
+  // test('look up retained messages with a + pattern', function (t) {
+  //   matchRetainedWithPattern(t, 'hello/+')
+  // })
 
   test('look up retained messages with multiple patterns', function (t) {
-    matchRetainedWithPattern(t, ['hello/+', 'other/hello'])
+    matchRetainedWithPattern(t, ['hello/world', 'other/hello'])
   })
 
   testInstance('store multiple retained messages in order', function (t, instance) {
@@ -165,7 +165,7 @@ function abstractPersistence (opts) {
       }, function (err) {
         t.notOk(err, 'no error')
 
-        const stream = instance.createRetainedStream('#')
+        const stream = instance.createRetainedStream('hello/world')
 
         stream.pipe(concat(function (list) {
           t.deepEqual(list, [], 'must return an empty list')
@@ -183,7 +183,7 @@ function abstractPersistence (opts) {
       }, function (err, packet) {
         t.notOk(err, 'no error')
 
-        const stream = instance.createRetainedStream('#')
+        const stream = instance.createRetainedStream('hello/world')
 
         stream.pipe(concat(function (list) {
           t.deepEqual(list, [packet], 'must return the last packet')
@@ -208,7 +208,7 @@ function abstractPersistence (opts) {
       t.notOk(err, 'no error')
       // packet reference change to check if a new packet is stored always
       packet.retain = false
-      const stream = instance.createRetainedStream('#')
+      const stream = instance.createRetainedStream('hello/world')
 
       stream.pipe(concat(function (list) {
         t.deepEqual(list, [newPacket], 'must return the last packet')


### PR DESCRIPTION
This repo is used to test Aedes persistence libs. As we have decided to restrict wildcard usage when subscribing to topics, I have removed the corresponding tests. Also added some tests for the core functionality that I have changed.