### PR TITLE
chore: update dependencies 

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -7,7 +7,7 @@ const Packet = require('aedes-packet')
 
 function abstractPersistence (opts) {
   const test = opts.test
-  var _persistence = opts.persistence
+  let _persistence = opts.persistence
   const waitForReady = opts.waitForReady
 
   // requiring it here so it will not error for modules
@@ -78,7 +78,7 @@ function abstractPersistence (opts) {
 
       storeRetained(instance, opts, function (err, packet) {
         t.notOk(err, 'no error')
-        var stream
+        let stream
         if (Array.isArray(pattern)) {
           stream = instance.createRetainedStreamCombi(pattern)
         } else {
@@ -130,7 +130,7 @@ function abstractPersistence (opts) {
 
   testInstance('store multiple retained messages in order', function (t, instance) {
     const totalMessages = 1000
-    var done = 0
+    let done = 0
 
     const retained = {
       cmd: 'publish',
@@ -761,7 +761,7 @@ function abstractPersistence (opts) {
       topic: 'hello2',
       qos: 1
     }]
-    var calls = 2
+    let calls = 2
 
     function done () {
       if (!--calls) {
@@ -821,7 +821,7 @@ function abstractPersistence (opts) {
       const stream = instance.outgoingStream(client)
 
       stream.pipe(concat(function (list) {
-        var packet = list[0]
+        const packet = list[0]
         testPacket(t, packet, expected)
         instance.destroy(t.end.bind(t))
       }))
@@ -873,12 +873,12 @@ function abstractPersistence (opts) {
       t.error(err)
       const stream = instance.outgoingStream(client)
       stream.pipe(concat(function (list) {
-        var packet = list[0]
+        const packet = list[0]
         testPacket(t, packet, expected)
 
         const stream2 = instance.outgoingStream(client2)
         stream2.pipe(concat(function (list) {
-          var packet = list[0]
+          const packet = list[0]
           testPacket(t, packet, expected)
           instance.destroy(t.end.bind(t))
         }))
@@ -973,7 +973,7 @@ function abstractPersistence (opts) {
       const stream = instance.outgoingStream(client)
 
       stream.pipe(concat(function (list) {
-        var packet = list[0]
+        const packet = list[0]
         testPacket(t, packet, expected)
         instance.destroy(t.end.bind(t))
       }))
@@ -1018,13 +1018,13 @@ function abstractPersistence (opts) {
       const stream = instance.outgoingStream(client)
 
       stream.pipe(concat(function (list) {
-        var packet = list[0]
+        const packet = list[0]
         testPacket(t, packet, expected)
 
         const stream = instance.outgoingStream(client)
 
         stream.pipe(concat(function (list) {
-          var packet = list[0]
+          const packet = list[0]
           testPacket(t, packet, expected)
           t.notEqual(packet, expected, 'packet must be a different object')
           instance.destroy(t.end.bind(t))

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "node": ">=10"
   },
   "devDependencies": {
+    "@types/node": "^17.0.24",
     "aedes": "^0.45.0",
     "concat-stream": "^2.0.0",
     "faucet": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -61,24 +61,24 @@
   },
   "devDependencies": {
     "@types/node": "^17.0.24",
-    "aedes": "^0.45.0",
+    "aedes": "^0.46.3",
     "concat-stream": "^2.0.0",
     "faucet": "0.0.1",
     "license-checker": "^25.0.1",
-    "mqemitter": "^4.4.0",
+    "mqemitter": "^4.5.0",
     "nyc": "^15.1.0",
     "pre-commit": "^1.2.2",
     "pump": "^3.0.0",
-    "release-it": "^14.2.0",
+    "release-it": "^14.14.2",
     "snazzy": "^9.0.0",
-    "standard": "^15.0.1",
-    "tape": "^5.2.1",
+    "standard": "^16.0.4",
+    "tape": "^5.5.3",
     "through2": "^4.0.2",
-    "tsd": "^0.14.0"
+    "tsd": "^0.20.0"
   },
   "dependencies": {
     "aedes-packet": "^2.3.1",
     "from2": "^2.3.0",
-    "qlobber": "^5.0.3"
+    "qlobber": "^6.0.0"
   }
 }

--- a/persistence.js
+++ b/persistence.js
@@ -42,7 +42,7 @@ function matchingStream (current, pattern) {
   const matcher = new QlobberTrue(QlobberOpts)
 
   if (Array.isArray(pattern)) {
-    for (var i = 0; i < pattern.length; i += 1) {
+    for (let i = 0; i < pattern.length; i += 1) {
       matcher.add(pattern[i])
     }
   } else {
@@ -50,7 +50,7 @@ function matchingStream (current, pattern) {
   }
 
   return from2.obj(function match (size, next) {
-    var entry
+    let entry
 
     while ((entry = current.shift()) != null) {
       if (matcher.test(entry.topic)) {
@@ -72,7 +72,7 @@ MemoryPersistence.prototype.createRetainedStreamCombi = function (patterns) {
 }
 
 MemoryPersistence.prototype.addSubscriptions = function (client, subs, cb) {
-  var stored = this._subscriptions.get(client.id)
+  let stored = this._subscriptions.get(client.id)
   const trie = this._trie
 
   if (!stored) {
@@ -81,7 +81,7 @@ MemoryPersistence.prototype.addSubscriptions = function (client, subs, cb) {
     this._clientsCount++
   }
 
-  for (var i = 0; i < subs.length; i += 1) {
+  for (let i = 0; i < subs.length; i += 1) {
     const sub = subs[i]
     const qos = stored.get(sub.topic)
     const hasQoSGreaterThanZero = (qos !== undefined) && (qos > 0)
@@ -108,7 +108,7 @@ MemoryPersistence.prototype.removeSubscriptions = function (client, subs, cb) {
   const trie = this._trie
 
   if (stored) {
-    for (var i = 0; i < subs.length; i += 1) {
+    for (let i = 0; i < subs.length; i += 1) {
       const topic = subs[i]
       const qos = stored.get(topic)
       if (qos !== undefined) {
@@ -129,7 +129,7 @@ MemoryPersistence.prototype.removeSubscriptions = function (client, subs, cb) {
 }
 
 MemoryPersistence.prototype.subscriptionsByClient = function (client, cb) {
-  var subs = null
+  let subs = null
   const stored = this._subscriptions.get(client.id)
   if (stored) {
     subs = []
@@ -173,7 +173,7 @@ MemoryPersistence.prototype.outgoingEnqueue = function (sub, packet, cb) {
 }
 
 MemoryPersistence.prototype.outgoingEnqueueCombi = function (subs, packet, cb) {
-  for (var i = 0; i < subs.length; i++) {
+  for (let i = 0; i < subs.length; i++) {
     _outgoingEnqueue.call(this, subs[i], packet)
   }
   process.nextTick(cb)
@@ -191,11 +191,11 @@ function _outgoingEnqueue (sub, packet) {
 MemoryPersistence.prototype.outgoingUpdate = function (client, packet, cb) {
   const clientId = client.id
   const outgoing = this._outgoing[clientId] || []
-  var temp
+  let temp
 
   this._outgoing[clientId] = outgoing
 
-  for (var i = 0; i < outgoing.length; i++) {
+  for (let i = 0; i < outgoing.length; i++) {
     temp = outgoing[i]
     if (temp.brokerId === packet.brokerId) {
       if (temp.brokerCounter === packet.brokerCounter) {
@@ -222,11 +222,11 @@ MemoryPersistence.prototype.outgoingUpdate = function (client, packet, cb) {
 MemoryPersistence.prototype.outgoingClearMessageId = function (client, packet, cb) {
   const clientId = client.id
   const outgoing = this._outgoing[clientId] || []
-  var temp
+  let temp
 
   this._outgoing[clientId] = outgoing
 
-  for (var i = 0; i < outgoing.length; i++) {
+  for (let i = 0; i < outgoing.length; i++) {
     temp = outgoing[i]
     if (temp.messageId === packet.messageId) {
       outgoing.splice(i, 1)
@@ -241,7 +241,7 @@ MemoryPersistence.prototype.outgoingStream = function (client) {
   const queue = [].concat(this._outgoing[client.id] || [])
 
   return from2.obj(function match (size, next) {
-    var entry
+    let entry
 
     if ((entry = queue.shift()) != null) {
       setImmediate(next, null, entry)
@@ -267,7 +267,7 @@ MemoryPersistence.prototype.incomingStorePacket = function (client, packet, cb) 
 MemoryPersistence.prototype.incomingGetPacket = function (client, packet, cb) {
   const id = client.id
   const store = this._incoming[id] || {}
-  var err = null
+  let err = null
 
   this._incoming[id] = store
 
@@ -282,7 +282,7 @@ MemoryPersistence.prototype.incomingDelPacket = function (client, packet, cb) {
   const id = client.id
   const store = this._incoming[id] || {}
   const toDelete = store[packet.messageId]
-  var err = null
+  let err = null
 
   if (!toDelete) {
     err = new Error('no such packet')
@@ -315,7 +315,7 @@ MemoryPersistence.prototype.streamWill = function (brokers) {
   const wills = this._wills
   brokers = brokers || {}
   return from2.obj(function match (size, next) {
-    var entry
+    let entry
 
     while ((entry = clients.shift()) != null) {
       if (!brokers[wills[entry].brokerId]) {
@@ -334,7 +334,7 @@ MemoryPersistence.prototype.getClientList = function (topic) {
   const clientSubs = this._subscriptions
   const entries = clientSubs.entries(clientSubs)
   return from2.obj(function match (size, next) {
-    var entry
+    let entry
     while (!(entry = entries.next()).done) {
       if (entry.value[1].has(topic)) {
         setImmediate(next, null, entry.value[0])


### PR DESCRIPTION
This PR updates all dependencies to the most current version

It also adds `@types/node` as `npm test` failed because of this module missing.

As Standard 16 is more strict than Standard 15 I also applied `standard --fix` hence the changes to persistence.js and abstract.js
No manual edits have been applied.

My plan is to do modernization (like the one done on aedes-persistence-level) in a seperate PR after this PR has been merged so I can start at a current version.

Kind regards,
Hans

