### PR TITLE
chore: es5 to es6, drop nodejs 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 13.x]
+        node-version: [14.x, 16.x, '*']
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -265,9 +265,9 @@ A persistence needs to pass all tests defined in
 in the following manner:
 
 ```js
-var test = require('tape').test
-var myperst = require('./')
-var abs = require('aedes-persistence/abstract')
+const test = require('tape').test
+const myperst = require('./')
+const abs = require('aedes-persistence/abstract')
 
 abs({
   test: test,
@@ -279,10 +279,10 @@ If you require some async stuff before returning, a callback is also
 supported:
 
 ```js
-var test = require('tape').test
-var myperst = require('./')
-var abs = require('aedes-persistence/abstract')
-var clean = require('./clean') // invented module
+const test = require('tape').test
+const myperst = require('./')
+const abs = require('aedes-persistence/abstract')
+const clean = require('./clean') // invented module
 
 abs({
   test: test,

--- a/abstract.js
+++ b/abstract.js
@@ -1,8 +1,3 @@
-'use strict'
-
-const concat = require('concat-stream')
-const pump = require('pump')
-const through = require('through2')
 const Packet = require('aedes-packet')
 
 function abstractPersistence (opts) {
@@ -31,7 +26,7 @@ function abstractPersistence (opts) {
       counter: 0
     }
 
-    _persistence(function (err, instance) {
+    _persistence((err, instance) => {
       if (instance) {
         // Wait for ready event, if applicable, to ensure the persistence isn't
         // destroyed while it's still being set up.
@@ -39,7 +34,7 @@ function abstractPersistence (opts) {
         if (waitForReady) {
           // We have to listen to 'ready' before setting broker because that
           // can result in 'ready' being emitted.
-          instance.on('ready', function () {
+          instance.on('ready', () => {
             instance.removeListener('error', cb)
             cb(null, instance)
           })
@@ -55,6 +50,20 @@ function abstractPersistence (opts) {
     })
   }
 
+  async function getArrayFromStream (stream) {
+    const list = []
+    for await (const item of stream) {
+      list.push(item)
+    }
+    return list
+  }
+
+  async function streamForEach (stream, fn) {
+    for await (const item of stream) {
+      fn(item)
+    }
+  }
+
   function storeRetained (instance, opts, cb) {
     opts = opts || {}
 
@@ -67,16 +76,16 @@ function abstractPersistence (opts) {
       retain: true
     }
 
-    instance.storeRetained(packet, function (err) {
+    instance.storeRetained(packet, err => {
       cb(err, packet)
     })
   }
 
   function matchRetainedWithPattern (t, pattern, opts) {
-    persistence(function (err, instance) {
+    persistence((err, instance) => {
       if (err) { throw err }
 
-      storeRetained(instance, opts, function (err, packet) {
+      storeRetained(instance, opts, (err, packet) => {
         t.notOk(err, 'no error')
         let stream
         if (Array.isArray(pattern)) {
@@ -85,17 +94,17 @@ function abstractPersistence (opts) {
           stream = instance.createRetainedStream(pattern)
         }
 
-        stream.pipe(concat(function (list) {
+        getArrayFromStream(stream).then(list => {
           t.deepEqual(list, [packet], 'must return the packet')
           instance.destroy(t.end.bind(t))
-        }))
+        })
       })
     })
   }
 
   function testInstance (title, cb) {
-    test(title, function (t) {
-      persistence(function (err, instance) {
+    test(title, t => {
+      persistence((err, instance) => {
         if (err) { throw err }
         cb(t, instance)
       })
@@ -108,27 +117,27 @@ function abstractPersistence (opts) {
     t.deepLooseEqual(packet, expected, 'must return the packet')
   }
 
-  test('store and look up retained messages', function (t) {
+  test('store and look up retained messages', t => {
     matchRetainedWithPattern(t, 'hello/world')
   })
 
-  test('look up retained messages with a # pattern', function (t) {
+  test('look up retained messages with a # pattern', t => {
     matchRetainedWithPattern(t, '#')
   })
 
-  test('look up retained messages with a hello/world/# pattern', function (t) {
+  test('look up retained messages with a hello/world/# pattern', t => {
     matchRetainedWithPattern(t, 'hello/world/#')
   })
 
-  test('look up retained messages with a + pattern', function (t) {
+  test('look up retained messages with a + pattern', t => {
     matchRetainedWithPattern(t, 'hello/+')
   })
 
-  test('look up retained messages with multiple patterns', function (t) {
+  test('look up retained messages with multiple patterns', t => {
     matchRetainedWithPattern(t, ['hello/+', 'other/hello'])
   })
 
-  testInstance('store multiple retained messages in order', function (t, instance) {
+  testInstance('store multiple retained messages in order', (t, instance) => {
     const totalMessages = 1000
     let done = 0
 
@@ -143,7 +152,7 @@ function abstractPersistence (opts) {
     function checkIndex (index) {
       const packet = new Packet(retained, instance.broker)
 
-      instance.storeRetained(packet, function (err) {
+      instance.storeRetained(packet, err => {
         t.notOk(err, 'no error')
         t.equal(packet.brokerCounter, index + 1, 'packet stored in order')
         if (++done === totalMessages) {
@@ -157,43 +166,42 @@ function abstractPersistence (opts) {
     }
   })
 
-  testInstance('remove retained message', function (t, instance) {
-    storeRetained(instance, {}, function (err, packet) {
+  testInstance('remove retained message', (t, instance) => {
+    storeRetained(instance, {}, (err, packet) => {
       t.notOk(err, 'no error')
       storeRetained(instance, {
         payload: Buffer.alloc(0)
-      }, function (err) {
+      }, err => {
         t.notOk(err, 'no error')
 
         const stream = instance.createRetainedStream('#')
-
-        stream.pipe(concat(function (list) {
+        getArrayFromStream(stream).then(list => {
           t.deepEqual(list, [], 'must return an empty list')
           instance.destroy(t.end.bind(t))
-        }))
+        })
       })
     })
   })
 
-  testInstance('storing twice a retained message should keep only the last', function (t, instance) {
-    storeRetained(instance, {}, function (err, packet) {
+  testInstance('storing twice a retained message should keep only the last', (t, instance) => {
+    storeRetained(instance, {}, (err, packet) => {
       t.notOk(err, 'no error')
       storeRetained(instance, {
         payload: Buffer.from('ahah')
-      }, function (err, packet) {
+      }, (err, packet) => {
         t.notOk(err, 'no error')
 
         const stream = instance.createRetainedStream('#')
 
-        stream.pipe(concat(function (list) {
+        getArrayFromStream(stream).then(list => {
           t.deepEqual(list, [packet], 'must return the last packet')
           instance.destroy(t.end.bind(t))
-        }))
+        })
       })
     })
   })
 
-  testInstance('Create a new packet while storing a retained message', function (t, instance) {
+  testInstance('Create a new packet while storing a retained message', (t, instance) => {
     const packet = {
       cmd: 'publish',
       id: instance.broker.id,
@@ -204,20 +212,20 @@ function abstractPersistence (opts) {
     }
     const newPacket = Object.assign({}, packet)
 
-    instance.storeRetained(packet, function (err) {
+    instance.storeRetained(packet, err => {
       t.notOk(err, 'no error')
       // packet reference change to check if a new packet is stored always
       packet.retain = false
       const stream = instance.createRetainedStream('#')
 
-      stream.pipe(concat(function (list) {
+      getArrayFromStream(stream).then(list => {
         t.deepEqual(list, [newPacket], 'must return the last packet')
         instance.destroy(t.end.bind(t))
-      }))
+      })
     })
   })
 
-  testInstance('store and look up subscriptions by client', function (t, instance) {
+  testInstance('store and look up subscriptions by client', (t, instance) => {
     const client = { id: 'abcde' }
     const subs = [{
       topic: 'hello',
@@ -230,10 +238,10 @@ function abstractPersistence (opts) {
       qos: 0
     }]
 
-    instance.addSubscriptions(client, subs, function (err, reClient) {
+    instance.addSubscriptions(client, subs, (err, reClient) => {
       t.equal(reClient, client, 'client must be the same')
       t.notOk(err, 'no error')
-      instance.subscriptionsByClient(client, function (err, resubs, reReClient) {
+      instance.subscriptionsByClient(client, (err, resubs, reReClient) => {
         t.equal(reReClient, client, 'client must be the same')
         t.notOk(err, 'no error')
         t.deepEqual(resubs, subs)
@@ -242,7 +250,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('remove subscriptions by client', function (t, instance) {
+  testInstance('remove subscriptions by client', (t, instance) => {
     const client = { id: 'abcde' }
     const subs = [{
       topic: 'hello',
@@ -252,12 +260,12 @@ function abstractPersistence (opts) {
       qos: 1
     }]
 
-    instance.addSubscriptions(client, subs, function (err, reClient) {
+    instance.addSubscriptions(client, subs, (err, reClient) => {
       t.notOk(err, 'no error')
-      instance.removeSubscriptions(client, ['hello'], function (err, reClient) {
+      instance.removeSubscriptions(client, ['hello'], (err, reClient) => {
         t.notOk(err, 'no error')
         t.equal(reClient, client, 'client must be the same')
-        instance.subscriptionsByClient(client, function (err, resubs, reClient) {
+        instance.subscriptionsByClient(client, (err, resubs, reClient) => {
           t.equal(reClient, client, 'client must be the same')
           t.notOk(err, 'no error')
           t.deepEqual(resubs, [{
@@ -270,7 +278,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('store and look up subscriptions by topic', function (t, instance) {
+  testInstance('store and look up subscriptions by topic', (t, instance) => {
     const client = { id: 'abcde' }
     const subs = [{
       topic: 'hello',
@@ -283,9 +291,9 @@ function abstractPersistence (opts) {
       qos: 1
     }]
 
-    instance.addSubscriptions(client, subs, function (err) {
+    instance.addSubscriptions(client, subs, err => {
       t.notOk(err, 'no error')
-      instance.subscriptionsByTopic('hello', function (err, resubs) {
+      instance.subscriptionsByTopic('hello', (err, resubs) => {
         t.notOk(err, 'no error')
         t.deepEqual(resubs, [{
           clientId: client.id,
@@ -301,7 +309,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('get client list after subscriptions', function (t, instance) {
+  testInstance('get client list after subscriptions', (t, instance) => {
     const client1 = { id: 'abcde' }
     const client2 = { id: 'efghi' }
     const subs = [{
@@ -309,44 +317,20 @@ function abstractPersistence (opts) {
       qos: 1
     }]
 
-    instance.addSubscriptions(client1, subs, function (err) {
+    instance.addSubscriptions(client1, subs, err => {
       t.notOk(err, 'no error for client 1')
-      instance.addSubscriptions(client2, subs, function (err) {
+      instance.addSubscriptions(client2, subs, err => {
         t.notOk(err, 'no error for client 2')
         const stream = instance.getClientList(subs[0].topic)
-        stream.pipe(concat({ encoding: 'object' }, function (out) {
+        getArrayFromStream(stream).then(out => {
           t.deepEqual(out, [client1.id, client2.id])
           instance.destroy(t.end.bind(t))
-        }))
-      })
-    })
-  })
-
-  testInstance('get client list after an unsubscribe', function (t, instance) {
-    const client1 = { id: 'abcde' }
-    const client2 = { id: 'efghi' }
-    const subs = [{
-      topic: 'helloagain',
-      qos: 1
-    }]
-
-    instance.addSubscriptions(client1, subs, function (err) {
-      t.notOk(err, 'no error for client 1')
-      instance.addSubscriptions(client2, subs, function (err) {
-        t.notOk(err, 'no error for client 2')
-        instance.removeSubscriptions(client2, [subs[0].topic], function (err, reClient) {
-          t.notOk(err, 'no error for removeSubscriptions')
-          const stream = instance.getClientList(subs[0].topic)
-          stream.pipe(concat({ encoding: 'object' }, function (out) {
-            t.deepEqual(out, [client1.id])
-            instance.destroy(t.end.bind(t))
-          }))
         })
       })
     })
   })
 
-  testInstance('get subscriptions list after an unsubscribe', function (t, instance) {
+  testInstance('get client list after an unsubscribe', (t, instance) => {
     const client1 = { id: 'abcde' }
     const client2 = { id: 'efghi' }
     const subs = [{
@@ -354,13 +338,37 @@ function abstractPersistence (opts) {
       qos: 1
     }]
 
-    instance.addSubscriptions(client1, subs, function (err) {
+    instance.addSubscriptions(client1, subs, err => {
       t.notOk(err, 'no error for client 1')
-      instance.addSubscriptions(client2, subs, function (err) {
+      instance.addSubscriptions(client2, subs, err => {
         t.notOk(err, 'no error for client 2')
-        instance.removeSubscriptions(client2, [subs[0].topic], function (err, reClient) {
+        instance.removeSubscriptions(client2, [subs[0].topic], (err, reClient) => {
           t.notOk(err, 'no error for removeSubscriptions')
-          instance.subscriptionsByTopic(subs[0].topic, function (err, clients) {
+          const stream = instance.getClientList(subs[0].topic)
+          getArrayFromStream(stream).then(out => {
+            t.deepEqual(out, [client1.id])
+            instance.destroy(t.end.bind(t))
+          })
+        })
+      })
+    })
+  })
+
+  testInstance('get subscriptions list after an unsubscribe', (t, instance) => {
+    const client1 = { id: 'abcde' }
+    const client2 = { id: 'efghi' }
+    const subs = [{
+      topic: 'helloagain',
+      qos: 1
+    }]
+
+    instance.addSubscriptions(client1, subs, err => {
+      t.notOk(err, 'no error for client 1')
+      instance.addSubscriptions(client2, subs, err => {
+        t.notOk(err, 'no error for client 2')
+        instance.removeSubscriptions(client2, [subs[0].topic], (err, reClient) => {
+          t.notOk(err, 'no error for removeSubscriptions')
+          instance.subscriptionsByTopic(subs[0].topic, (err, clients) => {
             t.notOk(err, 'no error getting subscriptions by topic')
             t.deepEqual(clients[0].clientId, client1.id)
             instance.destroy(t.end.bind(t))
@@ -370,7 +378,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('QoS 0 subscriptions, restored but not matched', function (t, instance) {
+  testInstance('QoS 0 subscriptions, restored but not matched', (t, instance) => {
     const client = { id: 'abcde' }
     const subs = [{
       topic: 'hello',
@@ -383,12 +391,12 @@ function abstractPersistence (opts) {
       qos: 1
     }]
 
-    instance.addSubscriptions(client, subs, function (err) {
+    instance.addSubscriptions(client, subs, err => {
       t.notOk(err, 'no error')
-      instance.subscriptionsByClient(client, function (err, resubs) {
+      instance.subscriptionsByClient(client, (err, resubs) => {
         t.notOk(err, 'no error')
         t.deepEqual(resubs, subs)
-        instance.subscriptionsByTopic('hello', function (err, resubs2) {
+        instance.subscriptionsByTopic('hello', (err, resubs2) => {
           t.notOk(err, 'no error')
           t.deepEqual(resubs2, [{
             clientId: client.id,
@@ -401,7 +409,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('clean subscriptions', function (t, instance) {
+  testInstance('clean subscriptions', (t, instance) => {
     const client = { id: 'abcde' }
     const subs = [{
       topic: 'hello',
@@ -411,19 +419,19 @@ function abstractPersistence (opts) {
       qos: 1
     }]
 
-    instance.addSubscriptions(client, subs, function (err) {
+    instance.addSubscriptions(client, subs, err => {
       t.notOk(err, 'no error')
-      instance.cleanSubscriptions(client, function (err) {
+      instance.cleanSubscriptions(client, err => {
         t.notOk(err, 'no error')
-        instance.subscriptionsByTopic('hello', function (err, resubs) {
+        instance.subscriptionsByTopic('hello', (err, resubs) => {
           t.notOk(err, 'no error')
           t.deepEqual(resubs, [], 'no subscriptions')
 
-          instance.subscriptionsByClient(client, function (err, resubs) {
+          instance.subscriptionsByClient(client, (err, resubs) => {
             t.error(err)
             t.deepEqual(resubs, null, 'no subscriptions')
 
-            instance.countOffline(function (err, subsCount, clientsCount) {
+            instance.countOffline((err, subsCount, clientsCount) => {
               t.error(err, 'no error')
               t.equal(subsCount, 0, 'no subscriptions added')
               t.equal(clientsCount, 0, 'no clients added')
@@ -436,20 +444,20 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('clean subscriptions with no active subscriptions', function (t, instance) {
+  testInstance('clean subscriptions with no active subscriptions', (t, instance) => {
     const client = { id: 'abcde' }
 
-    instance.cleanSubscriptions(client, function (err) {
+    instance.cleanSubscriptions(client, err => {
       t.notOk(err, 'no error')
-      instance.subscriptionsByTopic('hello', function (err, resubs) {
+      instance.subscriptionsByTopic('hello', (err, resubs) => {
         t.notOk(err, 'no error')
         t.deepEqual(resubs, [], 'no subscriptions')
 
-        instance.subscriptionsByClient(client, function (err, resubs) {
+        instance.subscriptionsByClient(client, (err, resubs) => {
           t.error(err)
           t.deepEqual(resubs, null, 'no subscriptions')
 
-          instance.countOffline(function (err, subsCount, clientsCount) {
+          instance.countOffline((err, subsCount, clientsCount) => {
             t.error(err, 'no error')
             t.equal(subsCount, 0, 'no subscriptions added')
             t.equal(clientsCount, 0, 'no clients added')
@@ -461,7 +469,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('same topic, different QoS', function (t, instance) {
+  testInstance('same topic, different QoS', (t, instance) => {
     const client = { id: 'abcde' }
     const subs = [{
       topic: 'hello',
@@ -471,18 +479,18 @@ function abstractPersistence (opts) {
       qos: 1
     }]
 
-    instance.addSubscriptions(client, subs, function (err, reClient) {
+    instance.addSubscriptions(client, subs, (err, reClient) => {
       t.equal(reClient, client, 'client must be the same')
       t.error(err, 'no error')
 
-      instance.subscriptionsByClient(client, function (err, subsForClient, client) {
+      instance.subscriptionsByClient(client, (err, subsForClient, client) => {
         t.error(err, 'no error')
         t.deepEqual(subsForClient, [{
           topic: 'hello',
           qos: 1
         }])
 
-        instance.subscriptionsByTopic('hello', function (err, subsForTopic) {
+        instance.subscriptionsByTopic('hello', (err, subsForTopic) => {
           t.error(err, 'no error')
           t.deepEqual(subsForTopic, [{
             clientId: 'abcde',
@@ -490,7 +498,7 @@ function abstractPersistence (opts) {
             qos: 1
           }])
 
-          instance.countOffline(function (err, subsCount, clientsCount) {
+          instance.countOffline((err, subsCount, clientsCount) => {
             t.error(err, 'no error')
             t.equal(subsCount, 1, 'one subscription added')
             t.equal(clientsCount, 1, 'one client added')
@@ -502,7 +510,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('replace subscriptions', function (t, instance) {
+  testInstance('replace subscriptions', (t, instance) => {
     const client = { id: 'abcde' }
     const topic = 'hello'
     const sub = { topic }
@@ -510,16 +518,16 @@ function abstractPersistence (opts) {
 
     function check (qos, cb) {
       sub.qos = subByTopic.qos = qos
-      instance.addSubscriptions(client, [sub], function (err, reClient) {
+      instance.addSubscriptions(client, [sub], (err, reClient) => {
         t.equal(reClient, client, 'client must be the same')
         t.error(err, 'no error')
-        instance.subscriptionsByClient(client, function (err, subsForClient, client) {
+        instance.subscriptionsByClient(client, (err, subsForClient, client) => {
           t.error(err, 'no error')
           t.deepEqual(subsForClient, [sub])
-          instance.subscriptionsByTopic(topic, function (err, subsForTopic) {
+          instance.subscriptionsByTopic(topic, (err, subsForTopic) => {
             t.error(err, 'no error')
             t.deepEqual(subsForTopic, qos === 0 ? [] : [subByTopic])
-            instance.countOffline(function (err, subsCount, clientsCount) {
+            instance.countOffline((err, subsCount, clientsCount) => {
               t.error(err, 'no error')
               if (qos === 0) {
                 t.equal(subsCount, 0, 'no subscriptions added')
@@ -534,11 +542,11 @@ function abstractPersistence (opts) {
       })
     }
 
-    check(0, function () {
-      check(1, function () {
-        check(2, function () {
-          check(1, function () {
-            check(0, function () {
+    check(0, () => {
+      check(1, () => {
+        check(2, () => {
+          check(1, () => {
+            check(0, () => {
               instance.destroy(t.end.bind(t))
             })
           })
@@ -547,7 +555,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('replace subscriptions in same call', function (t, instance) {
+  testInstance('replace subscriptions in same call', (t, instance) => {
     const client = { id: 'abcde' }
     const topic = 'hello'
     const subs = [
@@ -557,16 +565,16 @@ function abstractPersistence (opts) {
       { topic, qos: 1 },
       { topic, qos: 0 }
     ]
-    instance.addSubscriptions(client, subs, function (err, reClient) {
+    instance.addSubscriptions(client, subs, (err, reClient) => {
       t.equal(reClient, client, 'client must be the same')
       t.error(err, 'no error')
-      instance.subscriptionsByClient(client, function (err, subsForClient, client) {
+      instance.subscriptionsByClient(client, (err, subsForClient, client) => {
         t.error(err, 'no error')
         t.deepEqual(subsForClient, [{ topic, qos: 0 }])
-        instance.subscriptionsByTopic(topic, function (err, subsForTopic) {
+        instance.subscriptionsByTopic(topic, (err, subsForTopic) => {
           t.error(err, 'no error')
           t.deepEqual(subsForTopic, [])
-          instance.countOffline(function (err, subsCount, clientsCount) {
+          instance.countOffline((err, subsCount, clientsCount) => {
             t.error(err, 'no error')
             t.equal(subsCount, 0, 'no subscriptions added')
             t.equal(clientsCount, 1, 'one client added')
@@ -577,7 +585,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('store and count subscriptions', function (t, instance) {
+  testInstance('store and count subscriptions', (t, instance) => {
     const client = { id: 'abcde' }
     const subs = [{
       topic: 'hello',
@@ -590,43 +598,43 @@ function abstractPersistence (opts) {
       qos: 0
     }]
 
-    instance.addSubscriptions(client, subs, function (err, reClient) {
+    instance.addSubscriptions(client, subs, (err, reClient) => {
       t.equal(reClient, client, 'client must be the same')
       t.error(err, 'no error')
 
-      instance.countOffline(function (err, subsCount, clientsCount) {
+      instance.countOffline((err, subsCount, clientsCount) => {
         t.error(err, 'no error')
         t.equal(subsCount, 2, 'two subscriptions added')
         t.equal(clientsCount, 1, 'one client added')
 
-        instance.removeSubscriptions(client, ['hello'], function (err, reClient) {
+        instance.removeSubscriptions(client, ['hello'], (err, reClient) => {
           t.error(err, 'no error')
 
-          instance.countOffline(function (err, subsCount, clientsCount) {
+          instance.countOffline((err, subsCount, clientsCount) => {
             t.error(err, 'no error')
             t.equal(subsCount, 1, 'one subscription added')
             t.equal(clientsCount, 1, 'one client added')
 
-            instance.removeSubscriptions(client, ['matteo'], function (err, reClient) {
+            instance.removeSubscriptions(client, ['matteo'], (err, reClient) => {
               t.error(err, 'no error')
 
-              instance.countOffline(function (err, subsCount, clientsCount) {
+              instance.countOffline((err, subsCount, clientsCount) => {
                 t.error(err, 'no error')
                 t.equal(subsCount, 0, 'zero subscriptions added')
                 t.equal(clientsCount, 1, 'one client added')
 
-                instance.removeSubscriptions(client, ['noqos'], function (err, reClient) {
+                instance.removeSubscriptions(client, ['noqos'], (err, reClient) => {
                   t.error(err, 'no error')
 
-                  instance.countOffline(function (err, subsCount, clientsCount) {
+                  instance.countOffline((err, subsCount, clientsCount) => {
                     t.error(err, 'no error')
                     t.equal(subsCount, 0, 'zero subscriptions added')
                     t.equal(clientsCount, 0, 'zero clients added')
 
-                    instance.removeSubscriptions(client, ['noqos'], function (err, reClient) {
+                    instance.removeSubscriptions(client, ['noqos'], (err, reClient) => {
                       t.error(err, 'no error')
 
-                      instance.countOffline(function (err, subsCount, clientsCount) {
+                      instance.countOffline((err, subsCount, clientsCount) => {
                         t.error(err, 'no error')
                         t.equal(subsCount, 0, 'zero subscriptions added')
                         t.equal(clientsCount, 0, 'zero clients added')
@@ -644,7 +652,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('count subscriptions with two clients', function (t, instance) {
+  testInstance('count subscriptions with two clients', (t, instance) => {
     const client1 = { id: 'abcde' }
     const client2 = { id: 'fghij' }
     const subs = [{
@@ -659,11 +667,11 @@ function abstractPersistence (opts) {
     }]
 
     function remove (client, subs, expectedSubs, expectedClients, cb) {
-      instance.removeSubscriptions(client, subs, function (err, reClient) {
+      instance.removeSubscriptions(client, subs, (err, reClient) => {
         t.error(err, 'no error')
         t.equal(reClient, client, 'client must be the same')
 
-        instance.countOffline(function (err, subsCount, clientsCount) {
+        instance.countOffline((err, subsCount, clientsCount) => {
           t.error(err, 'no error')
           t.equal(subsCount, expectedSubs, 'subscriptions added')
           t.equal(clientsCount, expectedClients, 'clients added')
@@ -673,22 +681,22 @@ function abstractPersistence (opts) {
       })
     }
 
-    instance.addSubscriptions(client1, subs, function (err, reClient) {
+    instance.addSubscriptions(client1, subs, (err, reClient) => {
       t.equal(reClient, client1, 'client must be the same')
       t.error(err, 'no error')
 
-      instance.addSubscriptions(client2, subs, function (err, reClient) {
+      instance.addSubscriptions(client2, subs, (err, reClient) => {
         t.equal(reClient, client2, 'client must be the same')
         t.error(err, 'no error')
 
-        remove(client1, ['foobar'], 4, 2, function () {
-          remove(client1, ['hello'], 3, 2, function () {
-            remove(client1, ['hello'], 3, 2, function () {
-              remove(client1, ['matteo'], 2, 2, function () {
-                remove(client1, ['noqos'], 2, 1, function () {
-                  remove(client2, ['hello'], 1, 1, function () {
-                    remove(client2, ['matteo'], 0, 1, function () {
-                      remove(client2, ['noqos'], 0, 0, function () {
+        remove(client1, ['foobar'], 4, 2, () => {
+          remove(client1, ['hello'], 3, 2, () => {
+            remove(client1, ['hello'], 3, 2, () => {
+              remove(client1, ['matteo'], 2, 2, () => {
+                remove(client1, ['noqos'], 2, 1, () => {
+                  remove(client2, ['hello'], 1, 1, () => {
+                    remove(client2, ['matteo'], 0, 1, () => {
+                      remove(client2, ['noqos'], 0, 0, () => {
                         instance.destroy(t.end.bind(t))
                       })
                     })
@@ -702,7 +710,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('add duplicate subs to persistence for qos > 0', function (t, instance) {
+  testInstance('add duplicate subs to persistence for qos > 0', (t, instance) => {
     const client = { id: 'abcde' }
     const topic = 'hello'
     const subs = [{
@@ -710,15 +718,15 @@ function abstractPersistence (opts) {
       qos: 1
     }]
 
-    instance.addSubscriptions(client, subs, function (err, reClient) {
+    instance.addSubscriptions(client, subs, (err, reClient) => {
       t.equal(reClient, client, 'client must be the same')
       t.error(err, 'no error')
 
-      instance.addSubscriptions(client, subs, function (err, resCLient) {
+      instance.addSubscriptions(client, subs, (err, resCLient) => {
         t.equal(resCLient, client, 'client must be the same')
         t.error(err, 'no error')
         subs[0].clientId = client.id
-        instance.subscriptionsByTopic(topic, function (err, subsForTopic) {
+        instance.subscriptionsByTopic(topic, (err, subsForTopic) => {
           t.error(err, 'no error')
           t.deepEqual(subsForTopic, subs)
           instance.destroy(t.end.bind(t))
@@ -727,7 +735,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('add duplicate subs to persistence for qos 0', function (t, instance) {
+  testInstance('add duplicate subs to persistence for qos 0', (t, instance) => {
     const client = { id: 'abcde' }
     const topic = 'hello'
     const subs = [{
@@ -735,14 +743,14 @@ function abstractPersistence (opts) {
       qos: 0
     }]
 
-    instance.addSubscriptions(client, subs, function (err, reClient) {
+    instance.addSubscriptions(client, subs, (err, reClient) => {
       t.equal(reClient, client, 'client must be the same')
       t.error(err, 'no error')
 
-      instance.addSubscriptions(client, subs, function (err, resCLient) {
+      instance.addSubscriptions(client, subs, (err, resCLient) => {
         t.equal(resCLient, client, 'client must be the same')
         t.error(err, 'no error')
-        instance.subscriptionsByClient(client, function (err, subsForClient, client) {
+        instance.subscriptionsByClient(client, (err, subsForClient, client) => {
           t.error(err, 'no error')
           t.deepEqual(subsForClient, subs)
           instance.destroy(t.end.bind(t))
@@ -751,7 +759,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('get topic list after concurrent subscriptions of a client', function (t, instance) {
+  testInstance('get topic list after concurrent subscriptions of a client', (t, instance) => {
     const client = { id: 'abcde' }
     const subs1 = [{
       topic: 'hello1',
@@ -765,7 +773,7 @@ function abstractPersistence (opts) {
 
     function done () {
       if (!--calls) {
-        instance.subscriptionsByClient(client, function (err, resubs) {
+        instance.subscriptionsByClient(client, (err, resubs) => {
           t.notOk(err, 'no error')
           resubs.sort((a, b) => b.topic.localeCompare(b.topic, 'en'))
           t.deepEqual(resubs, [subs1[0], subs2[0]])
@@ -774,17 +782,17 @@ function abstractPersistence (opts) {
       }
     }
 
-    instance.addSubscriptions(client, subs1, function (err) {
+    instance.addSubscriptions(client, subs1, err => {
       t.notOk(err, 'no error for hello1')
       done()
     })
-    instance.addSubscriptions(client, subs2, function (err) {
+    instance.addSubscriptions(client, subs2, err => {
       t.notOk(err, 'no error for hello2')
       done()
     })
   })
 
-  testInstance('add outgoing packet and stream it', function (t, instance) {
+  testInstance('add outgoing packet and stream it', (t, instance) => {
     const sub = {
       clientId: 'abcde',
       topic: 'hello',
@@ -816,19 +824,19 @@ function abstractPersistence (opts) {
       messageId: undefined
     }
 
-    instance.outgoingEnqueue(sub, packet, function (err) {
+    instance.outgoingEnqueue(sub, packet, err => {
       t.error(err)
       const stream = instance.outgoingStream(client)
 
-      stream.pipe(concat(function (list) {
+      getArrayFromStream(stream).then(list => {
         const packet = list[0]
         testPacket(t, packet, expected)
         instance.destroy(t.end.bind(t))
-      }))
+      })
     })
   })
 
-  testInstance('add outgoing packet for multiple subs and stream to all', function (t, instance) {
+  testInstance('add outgoing packet for multiple subs and stream to all', (t, instance) => {
     const sub = {
       clientId: 'abcde',
       topic: 'hello',
@@ -869,24 +877,24 @@ function abstractPersistence (opts) {
       messageId: undefined
     }
 
-    instance.outgoingEnqueueCombi(subs, packet, function (err) {
+    instance.outgoingEnqueueCombi(subs, packet, err => {
       t.error(err)
       const stream = instance.outgoingStream(client)
-      stream.pipe(concat(function (list) {
+      getArrayFromStream(stream).then(list => {
         const packet = list[0]
         testPacket(t, packet, expected)
 
         const stream2 = instance.outgoingStream(client2)
-        stream2.pipe(concat(function (list) {
-          const packet = list[0]
+        getArrayFromStream(stream2).then(list2 => {
+          const packet = list2[0]
           testPacket(t, packet, expected)
           instance.destroy(t.end.bind(t))
-        }))
-      }))
+        })
+      })
     })
   })
 
-  testInstance('add outgoing packet as a string and pump', function (t, instance) {
+  testInstance('add outgoing packet as a string and pump', (t, instance) => {
     const sub = {
       clientId: 'abcde',
       topic: 'hello',
@@ -914,17 +922,18 @@ function abstractPersistence (opts) {
       brokerCounter: 50
     }
     const queue = []
-    enqueueAndUpdate(t, instance, client, sub, packet1, 42, function (updated1) {
-      enqueueAndUpdate(t, instance, client, sub, packet2, 43, function (updated2) {
+    enqueueAndUpdate(t, instance, client, sub, packet1, 42, updated1 => {
+      enqueueAndUpdate(t, instance, client, sub, packet2, 43, updated2 => {
         const stream = instance.outgoingStream(client)
-        pump(stream, through.obj(function clearQueue (data, enc, next) {
+
+        function clearQueue (data) {
           instance.outgoingUpdate(client, data,
-            function (err, client, packet) {
+            (err, client, packet) => {
               t.notOk(err, 'no error')
               queue.push(packet)
-              next()
             })
-        }), function done () {
+        }
+        streamForEach(stream, clearQueue).then(function done () {
           t.equal(queue.length, 2)
           if (queue.length === 2) {
             t.deepEqual(queue[0], updated1)
@@ -936,7 +945,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('add outgoing packet as a string and stream', function (t, instance) {
+  testInstance('add outgoing packet as a string and stream', (t, instance) => {
     const sub = {
       clientId: 'abcde',
       topic: 'hello',
@@ -968,19 +977,19 @@ function abstractPersistence (opts) {
       messageId: undefined
     }
 
-    instance.outgoingEnqueueCombi([sub], packet, function (err) {
+    instance.outgoingEnqueueCombi([sub], packet, err => {
       t.error(err)
       const stream = instance.outgoingStream(client)
 
-      stream.pipe(concat(function (list) {
+      getArrayFromStream(stream).then(list => {
         const packet = list[0]
         testPacket(t, packet, expected)
         instance.destroy(t.end.bind(t))
-      }))
+      })
     })
   })
 
-  testInstance('add outgoing packet and stream it twice', function (t, instance) {
+  testInstance('add outgoing packet and stream it twice', (t, instance) => {
     const sub = {
       clientId: 'abcde',
       topic: 'hello',
@@ -1013,33 +1022,33 @@ function abstractPersistence (opts) {
       messageId: undefined
     }
 
-    instance.outgoingEnqueueCombi([sub], packet, function (err) {
+    instance.outgoingEnqueueCombi([sub], packet, err => {
       t.error(err)
       const stream = instance.outgoingStream(client)
 
-      stream.pipe(concat(function (list) {
+      getArrayFromStream(stream).then(list => {
         const packet = list[0]
         testPacket(t, packet, expected)
 
-        const stream = instance.outgoingStream(client)
+        const stream2 = instance.outgoingStream(client)
 
-        stream.pipe(concat(function (list) {
-          const packet = list[0]
+        getArrayFromStream(stream2).then(list2 => {
+          const packet = list2[0]
           testPacket(t, packet, expected)
           t.notEqual(packet, expected, 'packet must be a different object')
           instance.destroy(t.end.bind(t))
-        }))
-      }))
+        })
+      })
     })
   })
 
   function enqueueAndUpdate (t, instance, client, sub, packet, messageId, callback) {
-    instance.outgoingEnqueueCombi([sub], packet, function (err) {
+    instance.outgoingEnqueueCombi([sub], packet, err => {
       t.error(err)
       const updated = new Packet(packet)
       updated.messageId = messageId
 
-      instance.outgoingUpdate(client, updated, function (err, reclient, repacket) {
+      instance.outgoingUpdate(client, updated, (err, reclient, repacket) => {
         t.error(err)
         t.equal(reclient, client, 'client matches')
         t.equal(repacket, updated, 'packet matches')
@@ -1048,7 +1057,7 @@ function abstractPersistence (opts) {
     })
   }
 
-  testInstance('add outgoing packet and update messageId', function (t, instance) {
+  testInstance('add outgoing packet and update messageId', (t, instance) => {
     const sub = {
       clientId: 'abcde', topic: 'hello', qos: 1
     }
@@ -1067,19 +1076,19 @@ function abstractPersistence (opts) {
       brokerCounter: 42
     }
 
-    enqueueAndUpdate(t, instance, client, sub, packet, 42, function (updated) {
+    enqueueAndUpdate(t, instance, client, sub, packet, 42, updated => {
       const stream = instance.outgoingStream(client)
       delete updated.messageId
-      stream.pipe(concat(function (list) {
+      getArrayFromStream(stream).then(list => {
         delete list[0].messageId
         t.notEqual(list[0], updated, 'must not be the same object')
         t.deepEqual(list, [updated], 'must return the packet')
         instance.destroy(t.end.bind(t))
-      }))
+      })
     })
   })
 
-  testInstance('add 2 outgoing packet and clear messageId', function (t, instance) {
+  testInstance('add 2 outgoing packet and clear messageId', (t, instance) => {
     const sub = {
       clientId: 'abcde', topic: 'hello', qos: 1
     }
@@ -1109,27 +1118,27 @@ function abstractPersistence (opts) {
       brokerCounter: 43
     }
 
-    enqueueAndUpdate(t, instance, client, sub, packet1, 42, function (updated1) {
-      enqueueAndUpdate(t, instance, client, sub, packet2, 43, function (updated2) {
-        instance.outgoingClearMessageId(client, updated1, function (err, packet) {
+    enqueueAndUpdate(t, instance, client, sub, packet1, 42, updated1 => {
+      enqueueAndUpdate(t, instance, client, sub, packet2, 43, updated2 => {
+        instance.outgoingClearMessageId(client, updated1, (err, packet) => {
           t.error(err)
           t.deepEqual(packet.messageId, 42, 'must have the same messageId')
           t.deepEqual(packet.payload.toString(), packet1.payload.toString(), 'must have original payload')
           t.deepEqual(packet.topic, packet1.topic, 'must have original topic')
           const stream = instance.outgoingStream(client)
           delete updated2.messageId
-          stream.pipe(concat(function (list) {
+          getArrayFromStream(stream).then(list => {
             delete list[0].messageId
             t.notEqual(list[0], updated2, 'must not be the same object')
             t.deepEqual(list, [updated2], 'must return the packet')
             instance.destroy(t.end.bind(t))
-          }))
+          })
         })
       })
     })
   })
 
-  testInstance('update to publish w/ same messageId', function (t, instance) {
+  testInstance('update to publish w/ same messageId', (t, instance) => {
     const sub = {
       clientId: 'abcde', topic: 'hello', qos: 1
     }
@@ -1161,26 +1170,26 @@ function abstractPersistence (opts) {
       messageId: 42
     }
 
-    instance.outgoingEnqueue(sub, packet1, function () {
-      instance.outgoingEnqueue(sub, packet2, function () {
-        instance.outgoingUpdate(client, packet1, function () {
-          instance.outgoingUpdate(client, packet2, function () {
+    instance.outgoingEnqueue(sub, packet1, () => {
+      instance.outgoingEnqueue(sub, packet2, () => {
+        instance.outgoingUpdate(client, packet1, () => {
+          instance.outgoingUpdate(client, packet2, () => {
             const stream = instance.outgoingStream(client)
-            stream.pipe(concat(function (list) {
+            getArrayFromStream(stream).then(list => {
               t.equal(list.length, 2, 'must have two items in queue')
               t.equal(list[0].brokerCounter, packet1.brokerCounter, 'brokerCounter must match')
               t.equal(list[0].messageId, packet1.messageId, 'messageId must match')
               t.equal(list[1].brokerCounter, packet2.brokerCounter, 'brokerCounter must match')
               t.equal(list[1].messageId, packet2.messageId, 'messageId must match')
               instance.destroy(t.end.bind(t))
-            }))
+            })
           })
         })
       })
     })
   })
 
-  testInstance('update to pubrel', function (t, instance) {
+  testInstance('update to pubrel', (t, instance) => {
     const sub = {
       clientId: 'abcde', topic: 'hello', qos: 1
     }
@@ -1199,12 +1208,12 @@ function abstractPersistence (opts) {
       brokerCounter: 42
     }
 
-    instance.outgoingEnqueueCombi([sub], packet, function (err) {
+    instance.outgoingEnqueueCombi([sub], packet, err => {
       t.error(err)
       const updated = new Packet(packet)
       updated.messageId = 42
 
-      instance.outgoingUpdate(client, updated, function (err, reclient, repacket) {
+      instance.outgoingUpdate(client, updated, (err, reclient, repacket) => {
         t.error(err)
         t.equal(reclient, client, 'client matches')
         t.equal(repacket, updated, 'packet matches')
@@ -1214,21 +1223,21 @@ function abstractPersistence (opts) {
           messageId: updated.messageId
         }
 
-        instance.outgoingUpdate(client, pubrel, function (err) {
+        instance.outgoingUpdate(client, pubrel, err => {
           t.error(err)
 
           const stream = instance.outgoingStream(client)
 
-          stream.pipe(concat(function (list) {
+          getArrayFromStream(stream).then(list => {
             t.deepEqual(list, [pubrel], 'must return the packet')
             instance.destroy(t.end.bind(t))
-          }))
+          })
         })
       })
     })
   })
 
-  testInstance('add incoming packet, get it, and clear with messageId', function (t, instance) {
+  testInstance('add incoming packet, get it, and clear with messageId', (t, instance) => {
     const client = {
       id: 'abcde'
     }
@@ -1243,12 +1252,12 @@ function abstractPersistence (opts) {
       messageId: 42
     }
 
-    instance.incomingStorePacket(client, packet, function (err) {
+    instance.incomingStorePacket(client, packet, err => {
       t.error(err)
 
       instance.incomingGetPacket(client, {
         messageId: packet.messageId
-      }, function (err, retrieved) {
+      }, (err, retrieved) => {
         t.error(err)
 
         // adjusting the objects so they match
@@ -1259,12 +1268,12 @@ function abstractPersistence (opts) {
         t.deepLooseEqual(retrieved, packet, 'retrieved packet must be deeply equal')
         t.notEqual(retrieved, packet, 'retrieved packet must not be the same objet')
 
-        instance.incomingDelPacket(client, retrieved, function (err) {
+        instance.incomingDelPacket(client, retrieved, err => {
           t.error(err)
 
           instance.incomingGetPacket(client, {
             messageId: packet.messageId
-          }, function (err, retrieved) {
+          }, (err, retrieved) => {
             t.ok(err, 'must error')
             instance.destroy(t.end.bind(t))
           })
@@ -1273,7 +1282,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('store, fetch and delete will message', function (t, instance) {
+  testInstance('store, fetch and delete will message', (t, instance) => {
     const client = {
       id: '12345'
     }
@@ -1284,19 +1293,19 @@ function abstractPersistence (opts) {
       retain: true
     }
 
-    instance.putWill(client, expected, function (err, c) {
+    instance.putWill(client, expected, (err, c) => {
       t.error(err, 'no error')
       t.equal(c, client, 'client matches')
-      instance.getWill(client, function (err, packet, c) {
+      instance.getWill(client, (err, packet, c) => {
         t.error(err, 'no error')
         t.deepEqual(packet, expected, 'will matches')
         t.equal(c, client, 'client matches')
         client.brokerId = packet.brokerId
-        instance.delWill(client, function (err, packet, c) {
+        instance.delWill(client, (err, packet, c) => {
           t.error(err, 'no error')
           t.deepEqual(packet, expected, 'will matches')
           t.equal(c, client, 'client matches')
-          instance.getWill(client, function (err, packet, c) {
+          instance.getWill(client, (err, packet, c) => {
             t.error(err, 'no error')
             t.notOk(packet, 'no will after del')
             t.equal(c, client, 'client matches')
@@ -1307,7 +1316,7 @@ function abstractPersistence (opts) {
     })
   })
 
-  testInstance('stream all will messages', function (t, instance) {
+  testInstance('stream all will messages', (t, instance) => {
     const client = {
       id: '12345'
     }
@@ -1318,10 +1327,10 @@ function abstractPersistence (opts) {
       retain: true
     }
 
-    instance.putWill(client, toWrite, function (err, c) {
+    instance.putWill(client, toWrite, (err, c) => {
       t.error(err, 'no error')
       t.equal(c, client, 'client matches')
-      instance.streamWill().pipe(through.obj(function (chunk, enc, cb) {
+      streamForEach(instance.streamWill(), (chunk) => {
         t.deepEqual(chunk, {
           clientId: client.id,
           brokerId: instance.broker.id,
@@ -1330,17 +1339,15 @@ function abstractPersistence (opts) {
           qos: 0,
           retain: true
         }, 'packet matches')
-        cb()
-        client.brokerId = chunk.brokerId
-        instance.delWill(client, function (err, result, client) {
+        instance.delWill(client, (err, result, client) => {
           t.error(err, 'no error')
           instance.destroy(t.end.bind(t))
         })
-      }))
+      })
     })
   })
 
-  testInstance('stream all will message for unknown brokers', function (t, instance) {
+  testInstance('stream all will message for unknown brokers', (t, instance) => {
     const originalId = instance.broker.id
     const client = {
       id: '42'
@@ -1361,37 +1368,34 @@ function abstractPersistence (opts) {
       retain: true
     }
 
-    instance.putWill(client, toWrite1, function (err, c) {
+    instance.putWill(client, toWrite1, (err, c) => {
       t.error(err, 'no error')
       t.equal(c, client, 'client matches')
       instance.broker.id = 'anotherBroker'
-      instance.putWill(anotherClient, toWrite2, function (err, c) {
+      instance.putWill(anotherClient, toWrite2, (err, c) => {
         t.error(err, 'no error')
         t.equal(c, anotherClient, 'client matches')
-        instance.streamWill({
+        streamForEach(instance.streamWill({
           anotherBroker: Date.now()
+        }), (chunk) => {
+          t.deepEqual(chunk, {
+            clientId: client.id,
+            brokerId: originalId,
+            topic: 'hello/died42',
+            payload: Buffer.from('muahahha'),
+            qos: 0,
+            retain: true
+          }, 'packet matches')
+          instance.delWill(client, (err, result, client) => {
+            t.error(err, 'no error')
+            instance.destroy(t.end.bind(t))
+          })
         })
-          .pipe(through.obj(function (chunk, enc, cb) {
-            t.deepEqual(chunk, {
-              clientId: client.id,
-              brokerId: originalId,
-              topic: 'hello/died42',
-              payload: Buffer.from('muahahha'),
-              qos: 0,
-              retain: true
-            }, 'packet matches')
-            cb()
-            client.brokerId = chunk.brokerId
-            instance.delWill(client, function (err, result, client) {
-              t.error(err, 'no error')
-              instance.destroy(t.end.bind(t))
-            })
-          }))
       })
     })
   })
 
-  testInstance('delete wills from dead brokers', function (t, instance) {
+  testInstance('delete wills from dead brokers', (t, instance) => {
     const client = {
       id: '42'
     }
@@ -1403,24 +1407,24 @@ function abstractPersistence (opts) {
       retain: true
     }
 
-    instance.putWill(client, toWrite1, function (err, c) {
+    instance.putWill(client, toWrite1, (err, c) => {
       t.error(err, 'no error')
       t.equal(c, client, 'client matches')
       instance.broker.id = 'anotherBroker'
       client.brokerId = instance.broker.id
-      instance.delWill(client, function (err, result, client) {
+      instance.delWill(client, (err, result, client) => {
         t.error(err, 'no error')
         instance.destroy(t.end.bind(t))
       })
     })
   })
 
-  testInstance('do not error if unkown messageId in outoingClearMessageId', function (t, instance) {
+  testInstance('do not error if unkown messageId in outoingClearMessageId', (t, instance) => {
     const client = {
       id: 'abc-123'
     }
 
-    instance.outgoingClearMessageId(client, 42, function (err) {
+    instance.outgoingClearMessageId(client, 42, err => {
       t.error(err)
       instance.destroy(t.end.bind(t))
     })

--- a/abstract.js
+++ b/abstract.js
@@ -1,3 +1,4 @@
+const { Readable } = require('stream')
 const Packet = require('aedes-packet')
 
 function abstractPersistence (opts) {
@@ -50,16 +51,25 @@ function abstractPersistence (opts) {
     })
   }
 
+  // legacy third party streams are typically not iterable
+  function iterableStream (stream) {
+    if (typeof stream[Symbol.iterator] !== 'function') {
+      return new Readable({ objectMode: true }).wrap(stream)
+    }
+    return stream
+  }
+  // end of legacy third party streams support
+
   async function getArrayFromStream (stream) {
     const list = []
-    for await (const item of stream) {
+    for await (const item of iterableStream(stream)) {
       list.push(item)
     }
     return list
   }
 
   async function streamForEach (stream, fn) {
-    for await (const item of stream) {
+    for await (const item of iterableStream(stream)) {
       fn(item)
     }
   }

--- a/package.json
+++ b/package.json
@@ -62,23 +62,19 @@
   "devDependencies": {
     "@types/node": "^17.0.24",
     "aedes": "^0.46.3",
-    "concat-stream": "^2.0.0",
     "faucet": "0.0.1",
     "license-checker": "^25.0.1",
     "mqemitter": "^4.5.0",
     "nyc": "^15.1.0",
     "pre-commit": "^1.2.2",
-    "pump": "^3.0.0",
     "release-it": "^14.14.2",
     "snazzy": "^9.0.0",
     "standard": "^16.0.4",
     "tape": "^5.5.3",
-    "through2": "^4.0.2",
     "tsd": "^0.20.0"
   },
   "dependencies": {
     "aedes-packet": "^2.3.1",
-    "from2": "^2.3.0",
     "qlobber": "^6.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "homepage": "https://github.com/moscajs/aedes-persistence#readme",
   "engines": {
-    "node": ">=10"
+    "node": ">=14"
   },
   "devDependencies": {
     "@types/node": "^17.0.24",

--- a/persistence.js
+++ b/persistence.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const from2 = require('from2')
 const QlobberSub = require('qlobber/aedes/qlobber-sub')
 const { QlobberTrue } = require('qlobber')
@@ -10,32 +8,308 @@ const QlobberOpts = {
   separator: '/'
 }
 
-function MemoryPersistence () {
-  if (!(this instanceof MemoryPersistence)) {
-    return new MemoryPersistence()
+class MemoryPersistence {
+  constructor () {
+    this._retained = []
+    // clientId -> topic -> qos
+    this._subscriptions = new Map()
+    this._clientsCount = 0
+    this._trie = new QlobberSub(QlobberOpts)
+    this._outgoing = {}
+    this._incoming = {}
+    this._wills = {}
   }
 
-  this._retained = []
-  // clientId -> topic -> qos
-  this._subscriptions = new Map()
-  this._clientsCount = 0
-  this._trie = new QlobberSub(QlobberOpts)
-  this._outgoing = {}
-  this._incoming = {}
-  this._wills = {}
+  storeRetained (packet, cb) {
+    packet = Object.assign({}, packet)
+    this._retained = this._retained.filter(matchTopic, packet)
+
+    if (packet.payload.length > 0) { this._retained.push(packet) }
+
+    cb(null)
+  }
+
+  createRetainedStream (pattern) {
+    return matchingStream([].concat(this._retained), pattern)
+  }
+
+  createRetainedStreamCombi (patterns) {
+    return matchingStream([].concat(this._retained), patterns)
+  }
+
+  addSubscriptions (client, subs, cb) {
+    let stored = this._subscriptions.get(client.id)
+    const trie = this._trie
+
+    if (!stored) {
+      stored = new Map()
+      this._subscriptions.set(client.id, stored)
+      this._clientsCount++
+    }
+
+    for (const sub of subs) {
+      const qos = stored.get(sub.topic)
+      const hasQoSGreaterThanZero = (qos !== undefined) && (qos > 0)
+      if (sub.qos > 0) {
+        trie.add(sub.topic, {
+          clientId: client.id,
+          topic: sub.topic,
+          qos: sub.qos
+        })
+      } else if (hasQoSGreaterThanZero) {
+        trie.remove(sub.topic, {
+          clientId: client.id,
+          topic: sub.topic
+        })
+      }
+      stored.set(sub.topic, sub.qos)
+    }
+
+    cb(null, client)
+  }
+
+  removeSubscriptions (client, subs, cb) {
+    const stored = this._subscriptions.get(client.id)
+    const trie = this._trie
+
+    if (stored) {
+      for (const topic of subs) {
+        const qos = stored.get(topic)
+        if (qos !== undefined) {
+          if (qos > 0) {
+            trie.remove(topic, { clientId: client.id, topic })
+          }
+          stored.delete(topic)
+        }
+      }
+
+      if (stored.size === 0) {
+        this._clientsCount--
+        this._subscriptions.delete(client.id)
+      }
+    }
+
+    cb(null, client)
+  }
+
+  subscriptionsByClient (client, cb) {
+    let subs = null
+    const stored = this._subscriptions.get(client.id)
+    if (stored) {
+      subs = []
+      for (const topicAndQos of stored) {
+        subs.push({ topic: topicAndQos[0], qos: topicAndQos[1] })
+      }
+    }
+    cb(null, subs, client)
+  }
+
+  countOffline (cb) {
+    return cb(null, this._trie.subscriptionsCount, this._clientsCount)
+  }
+
+  subscriptionsByTopic (pattern, cb) {
+    cb(null, this._trie.match(pattern))
+  }
+
+  cleanSubscriptions (client, cb) {
+    const trie = this._trie
+    const stored = this._subscriptions.get(client.id)
+
+    if (stored) {
+      for (const topicAndQos of stored) {
+        if (topicAndQos[1] > 0) {
+          const topic = topicAndQos[0]
+          trie.remove(topic, { clientId: client.id, topic })
+        }
+      }
+
+      this._clientsCount--
+      this._subscriptions.delete(client.id)
+    }
+
+    cb(null, client)
+  }
+
+  outgoingEnqueue (sub, packet, cb) {
+    _outgoingEnqueue.call(this, sub, packet)
+    process.nextTick(cb)
+  }
+
+  outgoingEnqueueCombi (subs, packet, cb) {
+    for (let i = 0; i < subs.length; i++) {
+      _outgoingEnqueue.call(this, subs[i], packet)
+    }
+    process.nextTick(cb)
+  }
+
+  outgoingUpdate (client, packet, cb) {
+    const clientId = client.id
+    const outgoing = this._outgoing[clientId] || []
+    let temp
+
+    this._outgoing[clientId] = outgoing
+
+    for (let i = 0; i < outgoing.length; i++) {
+      temp = outgoing[i]
+      if (temp.brokerId === packet.brokerId) {
+        if (temp.brokerCounter === packet.brokerCounter) {
+          temp.messageId = packet.messageId
+          return cb(null, client, packet)
+        }
+        /*
+                Maximum of messageId (packet identifier) is 65535 and will be rotated,
+                brokerCounter is to ensure the packet identifier be unique.
+                The for loop is going to search which packet messageId should be updated
+                in the _outgoing queue.
+                If there is a case that brokerCounter is different but messageId is same,
+                we need to let the loop keep searching
+                */
+      } else if (temp.messageId === packet.messageId) {
+        outgoing[i] = packet
+        return cb(null, client, packet)
+      }
+    }
+
+    cb(new Error('no such packet'), client, packet)
+  }
+
+  outgoingClearMessageId (client, packet, cb) {
+    const clientId = client.id
+    const outgoing = this._outgoing[clientId] || []
+    let temp
+
+    this._outgoing[clientId] = outgoing
+
+    for (let i = 0; i < outgoing.length; i++) {
+      temp = outgoing[i]
+      if (temp.messageId === packet.messageId) {
+        outgoing.splice(i, 1)
+        return cb(null, temp)
+      }
+    }
+
+    cb()
+  }
+
+  outgoingStream (client) {
+    const queue = [].concat(this._outgoing[client.id] || [])
+
+    return from2.obj(function match (size, next) {
+      let entry
+
+      if ((entry = queue.shift()) != null) {
+        setImmediate(next, null, entry)
+        return
+      }
+
+      if (!entry) { this.push(null) }
+    })
+  }
+
+  incomingStorePacket (client, packet, cb) {
+    const id = client.id
+    const store = this._incoming[id] || {}
+
+    this._incoming[id] = store
+
+    store[packet.messageId] = new Packet(packet)
+    store[packet.messageId].messageId = packet.messageId
+
+    cb(null)
+  }
+
+  incomingGetPacket (client, packet, cb) {
+    const id = client.id
+    const store = this._incoming[id] || {}
+    let err = null
+
+    this._incoming[id] = store
+
+    if (!store[packet.messageId]) {
+      err = new Error('no such packet')
+    }
+
+    cb(err, store[packet.messageId])
+  }
+
+  incomingDelPacket (client, packet, cb) {
+    const id = client.id
+    const store = this._incoming[id] || {}
+    const toDelete = store[packet.messageId]
+    let err = null
+
+    if (!toDelete) {
+      err = new Error('no such packet')
+    } else {
+      delete store[packet.messageId]
+    }
+
+    cb(err)
+  }
+
+  putWill (client, packet, cb) {
+    packet.brokerId = this.broker.id
+    packet.clientId = client.id
+    this._wills[client.id] = packet
+    cb(null, client)
+  }
+
+  getWill (client, cb) {
+    cb(null, this._wills[client.id], client)
+  }
+
+  delWill (client, cb) {
+    const will = this._wills[client.id]
+    delete this._wills[client.id]
+    cb(null, will, client)
+  }
+
+  streamWill (brokers) {
+    const clients = Object.keys(this._wills)
+    const wills = this._wills
+    brokers = brokers || {}
+    return from2.obj(function match (size, next) {
+      let entry
+
+      while ((entry = clients.shift()) != null) {
+        if (!brokers[wills[entry].brokerId]) {
+          setImmediate(next, null, wills[entry])
+          return
+        }
+      }
+
+      if (!entry) {
+        this.push(null)
+      }
+    })
+  }
+
+  getClientList (topic) {
+    const clientSubs = this._subscriptions
+    const entries = clientSubs.entries(clientSubs)
+    return from2.obj(function match (size, next) {
+      let entry
+      while (!(entry = entries.next()).done) {
+        if (entry.value[1].has(topic)) {
+          setImmediate(next, null, entry.value[0])
+          return
+        }
+      }
+      next(null, null)
+    })
+  }
+
+  destroy (cb) {
+    this._retained = null
+    if (cb) {
+      cb(null)
+    }
+  }
 }
 
 function matchTopic (p) {
   return p.topic !== this.topic
-}
-
-MemoryPersistence.prototype.storeRetained = function (packet, cb) {
-  packet = Object.assign({}, packet)
-  this._retained = this._retained.filter(matchTopic, packet)
-
-  if (packet.payload.length > 0) this._retained.push(packet)
-
-  cb(null)
 }
 
 function matchingStream (current, pattern) {
@@ -63,122 +337,6 @@ function matchingStream (current, pattern) {
   })
 }
 
-MemoryPersistence.prototype.createRetainedStream = function (pattern) {
-  return matchingStream([].concat(this._retained), pattern)
-}
-
-MemoryPersistence.prototype.createRetainedStreamCombi = function (patterns) {
-  return matchingStream([].concat(this._retained), patterns)
-}
-
-MemoryPersistence.prototype.addSubscriptions = function (client, subs, cb) {
-  let stored = this._subscriptions.get(client.id)
-  const trie = this._trie
-
-  if (!stored) {
-    stored = new Map()
-    this._subscriptions.set(client.id, stored)
-    this._clientsCount++
-  }
-
-  for (let i = 0; i < subs.length; i += 1) {
-    const sub = subs[i]
-    const qos = stored.get(sub.topic)
-    const hasQoSGreaterThanZero = (qos !== undefined) && (qos > 0)
-    if (sub.qos > 0) {
-      trie.add(sub.topic, {
-        clientId: client.id,
-        topic: sub.topic,
-        qos: sub.qos
-      })
-    } else if (hasQoSGreaterThanZero) {
-      trie.remove(sub.topic, {
-        clientId: client.id,
-        topic: sub.topic
-      })
-    }
-    stored.set(sub.topic, sub.qos)
-  }
-
-  cb(null, client)
-}
-
-MemoryPersistence.prototype.removeSubscriptions = function (client, subs, cb) {
-  const stored = this._subscriptions.get(client.id)
-  const trie = this._trie
-
-  if (stored) {
-    for (let i = 0; i < subs.length; i += 1) {
-      const topic = subs[i]
-      const qos = stored.get(topic)
-      if (qos !== undefined) {
-        if (qos > 0) {
-          trie.remove(topic, { clientId: client.id, topic })
-        }
-        stored.delete(topic)
-      }
-    }
-
-    if (stored.size === 0) {
-      this._clientsCount--
-      this._subscriptions.delete(client.id)
-    }
-  }
-
-  cb(null, client)
-}
-
-MemoryPersistence.prototype.subscriptionsByClient = function (client, cb) {
-  let subs = null
-  const stored = this._subscriptions.get(client.id)
-  if (stored) {
-    subs = []
-    for (const topicAndQos of stored) {
-      subs.push({ topic: topicAndQos[0], qos: topicAndQos[1] })
-    }
-  }
-  cb(null, subs, client)
-}
-
-MemoryPersistence.prototype.countOffline = function (cb) {
-  return cb(null, this._trie.subscriptionsCount, this._clientsCount)
-}
-
-MemoryPersistence.prototype.subscriptionsByTopic = function (pattern, cb) {
-  cb(null, this._trie.match(pattern))
-}
-
-MemoryPersistence.prototype.cleanSubscriptions = function (client, cb) {
-  const trie = this._trie
-  const stored = this._subscriptions.get(client.id)
-
-  if (stored) {
-    for (const topicAndQos of stored) {
-      if (topicAndQos[1] > 0) {
-        const topic = topicAndQos[0]
-        trie.remove(topic, { clientId: client.id, topic })
-      }
-    }
-
-    this._clientsCount--
-    this._subscriptions.delete(client.id)
-  }
-
-  cb(null, client)
-}
-
-MemoryPersistence.prototype.outgoingEnqueue = function (sub, packet, cb) {
-  _outgoingEnqueue.call(this, sub, packet)
-  process.nextTick(cb)
-}
-
-MemoryPersistence.prototype.outgoingEnqueueCombi = function (subs, packet, cb) {
-  for (let i = 0; i < subs.length; i++) {
-    _outgoingEnqueue.call(this, subs[i], packet)
-  }
-  process.nextTick(cb)
-}
-
 function _outgoingEnqueue (sub, packet) {
   const id = sub.clientId
   const queue = this._outgoing[id] || []
@@ -188,169 +346,6 @@ function _outgoingEnqueue (sub, packet) {
   queue[queue.length] = p
 }
 
-MemoryPersistence.prototype.outgoingUpdate = function (client, packet, cb) {
-  const clientId = client.id
-  const outgoing = this._outgoing[clientId] || []
-  let temp
-
-  this._outgoing[clientId] = outgoing
-
-  for (let i = 0; i < outgoing.length; i++) {
-    temp = outgoing[i]
-    if (temp.brokerId === packet.brokerId) {
-      if (temp.brokerCounter === packet.brokerCounter) {
-        temp.messageId = packet.messageId
-        return cb(null, client, packet)
-      }
-      /*
-      Maximum of messageId (packet identifier) is 65535 and will be rotated,
-      brokerCounter is to ensure the packet identifier be unique.
-      The for loop is going to search which packet messageId should be updated
-      in the _outgoing queue.
-      If there is a case that brokerCounter is different but messageId is same,
-      we need to let the loop keep searching
-      */
-    } else if (temp.messageId === packet.messageId) {
-      outgoing[i] = packet
-      return cb(null, client, packet)
-    }
-  }
-
-  cb(new Error('no such packet'), client, packet)
-}
-
-MemoryPersistence.prototype.outgoingClearMessageId = function (client, packet, cb) {
-  const clientId = client.id
-  const outgoing = this._outgoing[clientId] || []
-  let temp
-
-  this._outgoing[clientId] = outgoing
-
-  for (let i = 0; i < outgoing.length; i++) {
-    temp = outgoing[i]
-    if (temp.messageId === packet.messageId) {
-      outgoing.splice(i, 1)
-      return cb(null, temp)
-    }
-  }
-
-  cb()
-}
-
-MemoryPersistence.prototype.outgoingStream = function (client) {
-  const queue = [].concat(this._outgoing[client.id] || [])
-
-  return from2.obj(function match (size, next) {
-    let entry
-
-    if ((entry = queue.shift()) != null) {
-      setImmediate(next, null, entry)
-      return
-    }
-
-    if (!entry) this.push(null)
-  })
-}
-
-MemoryPersistence.prototype.incomingStorePacket = function (client, packet, cb) {
-  const id = client.id
-  const store = this._incoming[id] || {}
-
-  this._incoming[id] = store
-
-  store[packet.messageId] = new Packet(packet)
-  store[packet.messageId].messageId = packet.messageId
-
-  cb(null)
-}
-
-MemoryPersistence.prototype.incomingGetPacket = function (client, packet, cb) {
-  const id = client.id
-  const store = this._incoming[id] || {}
-  let err = null
-
-  this._incoming[id] = store
-
-  if (!store[packet.messageId]) {
-    err = new Error('no such packet')
-  }
-
-  cb(err, store[packet.messageId])
-}
-
-MemoryPersistence.prototype.incomingDelPacket = function (client, packet, cb) {
-  const id = client.id
-  const store = this._incoming[id] || {}
-  const toDelete = store[packet.messageId]
-  let err = null
-
-  if (!toDelete) {
-    err = new Error('no such packet')
-  } else {
-    delete store[packet.messageId]
-  }
-
-  cb(err)
-}
-
-MemoryPersistence.prototype.putWill = function (client, packet, cb) {
-  packet.brokerId = this.broker.id
-  packet.clientId = client.id
-  this._wills[client.id] = packet
-  cb(null, client)
-}
-
-MemoryPersistence.prototype.getWill = function (client, cb) {
-  cb(null, this._wills[client.id], client)
-}
-
-MemoryPersistence.prototype.delWill = function (client, cb) {
-  const will = this._wills[client.id]
-  delete this._wills[client.id]
-  cb(null, will, client)
-}
-
-MemoryPersistence.prototype.streamWill = function (brokers) {
-  const clients = Object.keys(this._wills)
-  const wills = this._wills
-  brokers = brokers || {}
-  return from2.obj(function match (size, next) {
-    let entry
-
-    while ((entry = clients.shift()) != null) {
-      if (!brokers[wills[entry].brokerId]) {
-        setImmediate(next, null, wills[entry])
-        return
-      }
-    }
-
-    if (!entry) {
-      this.push(null)
-    }
-  })
-}
-
-MemoryPersistence.prototype.getClientList = function (topic) {
-  const clientSubs = this._subscriptions
-  const entries = clientSubs.entries(clientSubs)
-  return from2.obj(function match (size, next) {
-    let entry
-    while (!(entry = entries.next()).done) {
-      if (entry.value[1].has(topic)) {
-        setImmediate(next, null, entry.value[0])
-        return
-      }
-    }
-    next(null, null)
-  })
-}
-
-MemoryPersistence.prototype.destroy = function (cb) {
-  this._retained = null
-  if (cb) {
-    cb(null)
-  }
-}
-
-module.exports = MemoryPersistence
+module.exports = () => { return new MemoryPersistence() }
+module.exports.MemoryPersistence = MemoryPersistence
 module.exports.Packet = Packet

--- a/persistence.js
+++ b/persistence.js
@@ -312,12 +312,11 @@ function _outgoingEnqueue (sub, packet) {
 }
 
 function getMapRef (map, key, ifEmpty, createOnEmpty = false) {
-  let value = map.get(key)
+  const value = map.get(key)
   if (value === undefined && createOnEmpty) {
-    value = ifEmpty
-    map.set(key, value)
+    map.set(key, ifEmpty)
   }
-  return value
+  return value || ifEmpty
 }
 
 module.exports = () => { return new MemoryPersistence() }


### PR DESCRIPTION
Items on the shopping list I hope to achieve in this PR:

- [X] Set minimum NodeJS version 14 (and update CI testing as well to match)
- [X] Migrate persistence.js 
   -  [X] Migrate from ES5 classes to ES6 classes
   -  [X] other ES5 to ES6 optimizations
   -  [X] replace internal use of third party streams by generators/Node native streams where possible
- [X] Migrate abstract.js 
   -  [X] Migrate from ES5 classes to ES6 classes
   -  [X] other ES5 to ES6 optimizations
   -  [X] replace internal use of third party streams by generators/Node native streams where possible
- [X]  Update README code snippets to ES6
- [X] Check Typescript definition 

All while maintaining the abstract interface, hence the two step approach so we can't accidentally mess up either of them ;-)
If I missed anything just let me know.
I created this as a draft PR so you can follow along.

Kind regards,
Hans