### PR TITLE
chore: upgrade to standardjs@17 and private class members

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "node": ">=14"
   },
   "devDependencies": {
-    "@types/node": "^17.0.24",
+    "@types/node": "^17.0.29",
     "aedes": "^0.46.3",
     "faucet": "0.0.1",
     "license-checker": "^25.0.1",
@@ -69,7 +69,7 @@
     "pre-commit": "^1.2.2",
     "release-it": "^14.14.2",
     "snazzy": "^9.0.0",
-    "standard": "^16.0.4",
+    "standard": "^17.0.0",
     "tape": "^5.5.3",
     "tsd": "^0.20.0"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -144,19 +144,19 @@ export interface AedesPersistence {
 }
 
 export class AedesMemoryPersistence implements AedesPersistence {
-  _retained: Map<Topic, AedesPacket>;
-  _subscriptions: Map<
+  #retained: Map<Topic, AedesPacket>;
+  #subscriptions: Map<
     ClientId,
     Map<
       Topic,
       QoS
     >
   >;
-  _clientsCount: number;
-  _trie: any;
-  _outgoing: Map<ClientId, AedesPacket[]>;
-  _incoming: Map<ClientId, Incoming>;
-  _wills: Map<ClientId, WillPacket>;
+  #clientsCount: number;
+  #trie: any;
+  #outgoing: Map<ClientId, AedesPacket[]>;
+  #incoming: Map<ClientId, Incoming>;
+  #wills: Map<ClientId, WillPacket>;
 
   constructor();
 
@@ -206,6 +206,11 @@ export class AedesMemoryPersistence implements AedesPersistence {
   cleanSubscriptions: (
     client: Client,
     cb: (error: CallbackError, client: Client) => void,
+  ) => void;
+
+  #outgoingEnqueuePerSub: (
+    sub: { clientId: ClientId },
+    packet: AedesPacket,
   ) => void;
 
   outgoingEnqueue: (


### PR DESCRIPTION
Standardjs 17 has just been released and now supports ECMA script standard [private class features](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Classes/Private_class_fields) (starting with '#')
This PR updates the dependency and updates the code to use ECMA script standard private class members.

Kind regards,
Hans
