### PR TITLE
feat: persist rh, rap, nl

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -243,13 +243,22 @@ function abstractPersistence (opts) {
     const client = { id: 'abcde' }
     const subs = [{
       topic: 'hello',
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }, {
       topic: 'matteo',
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }, {
       topic: 'noqos',
-      qos: 0
+      qos: 0,
+      rh: 0,
+      rap: true,
+      nl: false
     }]
 
     instance.addSubscriptions(client, subs, (err, reClient) => {
@@ -268,10 +277,16 @@ function abstractPersistence (opts) {
     const client = { id: 'abcde' }
     const subs = [{
       topic: 'hello',
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }, {
       topic: 'matteo',
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }]
 
     instance.addSubscriptions(client, subs, (err, reClient) => {
@@ -284,7 +299,10 @@ function abstractPersistence (opts) {
           t.notOk(err, 'no error')
           t.deepEqual(resubs, [{
             topic: 'matteo',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
           }])
           instance.destroy(t.end.bind(t))
         })
@@ -296,13 +314,22 @@ function abstractPersistence (opts) {
     const client = { id: 'abcde' }
     const subs = [{
       topic: 'hello',
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }, {
       topic: 'hello/#',
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }, {
       topic: 'matteo',
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }]
 
     instance.addSubscriptions(client, subs, err => {
@@ -312,7 +339,10 @@ function abstractPersistence (opts) {
         t.deepEqual(resubs, [{
           clientId: client.id,
           topic: 'hello/#',
-          qos: 1
+          qos: 1,
+          rh: 0,
+          rap: true,
+          nl: false
         }, {
           clientId: client.id,
           topic: 'hello',
@@ -396,13 +426,22 @@ function abstractPersistence (opts) {
     const client = { id: 'abcde' }
     const subs = [{
       topic: 'hello',
-      qos: 0
+      qos: 0,
+      rh: 0,
+      rap: true,
+      nl: false
     }, {
       topic: 'hello/#',
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }, {
       topic: 'matteo',
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }]
 
     instance.addSubscriptions(client, subs, err => {
@@ -415,7 +454,10 @@ function abstractPersistence (opts) {
           t.deepEqual(resubs2, [{
             clientId: client.id,
             topic: 'hello/#',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
           }])
           instance.destroy(t.end.bind(t))
         })
@@ -487,10 +529,16 @@ function abstractPersistence (opts) {
     const client = { id: 'abcde' }
     const subs = [{
       topic: 'hello',
-      qos: 0
+      qos: 0,
+      rh: 0,
+      rap: true,
+      nl: false
     }, {
       topic: 'hello',
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }]
 
     instance.addSubscriptions(client, subs, (err, reClient) => {
@@ -501,7 +549,10 @@ function abstractPersistence (opts) {
         t.error(err, 'no error')
         t.deepEqual(subsForClient, [{
           topic: 'hello',
-          qos: 1
+          qos: 1,
+          rh: 0,
+          rap: true,
+          nl: false
         }])
 
         instance.subscriptionsByTopic('hello', (err, subsForTopic) => {
@@ -509,7 +560,10 @@ function abstractPersistence (opts) {
           t.deepEqual(subsForTopic, [{
             clientId: 'abcde',
             topic: 'hello',
-            qos: 1
+            qos: 1,
+            rh: 0,
+            rap: true,
+            nl: false
           }])
 
           instance.countOffline((err, subsCount, clientsCount) => {
@@ -527,7 +581,7 @@ function abstractPersistence (opts) {
   testInstance('replace subscriptions', (t, instance) => {
     const client = { id: 'abcde' }
     const topic = 'hello'
-    const sub = { topic }
+    const sub = { topic, rh: 0, rap: true, nl: false }
     const subByTopic = { clientId: client.id, topic }
 
     function check (qos, cb) {
@@ -573,18 +627,18 @@ function abstractPersistence (opts) {
     const client = { id: 'abcde' }
     const topic = 'hello'
     const subs = [
-      { topic, qos: 0 },
-      { topic, qos: 1 },
-      { topic, qos: 2 },
-      { topic, qos: 1 },
-      { topic, qos: 0 }
+      { topic, qos: 0, rh: 0, rap: true, nl: false },
+      { topic, qos: 1, rh: 0, rap: true, nl: false },
+      { topic, qos: 2, rh: 0, rap: true, nl: false },
+      { topic, qos: 1, rh: 0, rap: true, nl: false },
+      { topic, qos: 0, rh: 0, rap: true, nl: false }
     ]
     instance.addSubscriptions(client, subs, (err, reClient) => {
       t.equal(reClient, client, 'client must be the same')
       t.error(err, 'no error')
       instance.subscriptionsByClient(client, (err, subsForClient, client) => {
         t.error(err, 'no error')
-        t.deepEqual(subsForClient, [{ topic, qos: 0 }])
+        t.deepEqual(subsForClient, [{ topic, qos: 0, rh: 0, rap: true, nl: false }])
         instance.subscriptionsByTopic(topic, (err, subsForTopic) => {
           t.error(err, 'no error')
           t.deepEqual(subsForTopic, [])
@@ -754,7 +808,10 @@ function abstractPersistence (opts) {
     const topic = 'hello'
     const subs = [{
       topic,
-      qos: 0
+      qos: 0,
+      rh: 0,
+      rap: true,
+      nl: false
     }]
 
     instance.addSubscriptions(client, subs, (err, reClient) => {
@@ -777,11 +834,17 @@ function abstractPersistence (opts) {
     const client = { id: 'abcde' }
     const subs1 = [{
       topic: 'hello1',
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }]
     const subs2 = [{
       topic: 'hello2',
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }]
     let calls = 2
 

--- a/abstract.js
+++ b/abstract.js
@@ -346,7 +346,10 @@ function abstractPersistence (opts) {
         }, {
           clientId: client.id,
           topic: 'hello',
-          qos: 1
+          qos: 1,
+          rh: 0,
+          rap: true,
+          nl: false
         }])
         instance.destroy(t.end.bind(t))
       })
@@ -582,7 +585,7 @@ function abstractPersistence (opts) {
     const client = { id: 'abcde' }
     const topic = 'hello'
     const sub = { topic, rh: 0, rap: true, nl: false }
-    const subByTopic = { clientId: client.id, topic }
+    const subByTopic = { clientId: client.id, topic, rh: 0, rap: true, nl: false }
 
     function check (qos, cb) {
       sub.qos = subByTopic.qos = qos
@@ -783,7 +786,10 @@ function abstractPersistence (opts) {
     const topic = 'hello'
     const subs = [{
       topic,
-      qos: 1
+      qos: 1,
+      rh: 0,
+      rap: true,
+      nl: false
     }]
 
     instance.addSubscriptions(client, subs, (err, reClient) => {

--- a/package.json
+++ b/package.json
@@ -75,6 +75,6 @@
   },
   "dependencies": {
     "aedes-packet": "^2.3.1",
-    "qlobber": "^6.0.0"
+    "qlobber": "^7.0.0"
   }
 }

--- a/persistence.js
+++ b/persistence.js
@@ -101,7 +101,7 @@ class MemoryPersistence {
 
     for (const sub of subs) {
       const storedSub = stored.get(sub.topic)
-      const hasQoSGreaterThanZero = storedSub && (storedSub.qos !== undefined) && (storedSub.qos > 0)
+      const hasQoSGreaterThanZero = storedSub?.qos > 0
       if (sub.qos > 0) {
         trie.add(sub.topic, {
           clientId: client.id,

--- a/persistence.js
+++ b/persistence.js
@@ -101,7 +101,6 @@ class MemoryPersistence {
 
     for (const sub of subs) {
       const storedSub = stored.get(sub.topic)
-      const hasQoSGreaterThanZero = storedSub?.qos > 0
       if (sub.qos > 0) {
         trie.add(sub.topic, {
           clientId: client.id,
@@ -111,7 +110,7 @@ class MemoryPersistence {
           rap: sub.rap,
           nl: sub.nl
         })
-      } else if (hasQoSGreaterThanZero) {
+      } else if (storedSub?.qos > 0) {
         trie.remove(sub.topic, {
           clientId: client.id,
           topic: sub.topic

--- a/persistence.js
+++ b/persistence.js
@@ -56,7 +56,7 @@ class MemoryPersistence {
     // using Maps for convenience and security (risk on prototype polution)
     // Map ( topic -> packet )
     this.#retained = new Map()
-    // Map ( clientId -> Map( topic -> qos ))
+    // Map ( clientId -> Map( topic -> { qos, rh, rap, nl } ))
     this.#subscriptions = new Map()
     // Map ( clientId  > [ packet ] }
     this.#outgoing = new Map()
@@ -100,13 +100,16 @@ class MemoryPersistence {
     }
 
     for (const sub of subs) {
-      const qos = stored.get(sub.topic)
-      const hasQoSGreaterThanZero = (qos !== undefined) && (qos > 0)
+      const storedSub = stored.get(sub.topic)
+      const hasQoSGreaterThanZero = storedSub && (storedSub.qos !== undefined) && (storedSub.qos > 0)
       if (sub.qos > 0) {
         trie.add(sub.topic, {
           clientId: client.id,
           topic: sub.topic,
-          qos: sub.qos
+          qos: sub.qos,
+          rh: sub.rh,
+          rap: sub.rap,
+          nl: sub.nl
         })
       } else if (hasQoSGreaterThanZero) {
         trie.remove(sub.topic, {
@@ -114,7 +117,7 @@ class MemoryPersistence {
           topic: sub.topic
         })
       }
-      stored.set(sub.topic, sub.qos)
+      stored.set(sub.topic, { qos: sub.qos, rh: sub.rh, rap: sub.rap, nl: sub.nl })
     }
 
     cb(null, client)
@@ -126,9 +129,9 @@ class MemoryPersistence {
 
     if (stored) {
       for (const topic of subs) {
-        const qos = stored.get(topic)
-        if (qos !== undefined) {
-          if (qos > 0) {
+        const storedSub = stored.get(topic)
+        if (storedSub !== undefined) {
+          if (storedSub.qos > 0) {
             trie.remove(topic, { clientId: client.id, topic })
           }
           stored.delete(topic)
@@ -149,8 +152,8 @@ class MemoryPersistence {
     const stored = this.#subscriptions.get(client.id)
     if (stored) {
       subs = []
-      for (const topicAndQos of stored) {
-        subs.push({ topic: topicAndQos[0], qos: topicAndQos[1] })
+      for (const [topic, storedSub] of stored) {
+        subs.push({ topic, ...storedSub })
       }
     }
     cb(null, subs, client)
@@ -169,9 +172,8 @@ class MemoryPersistence {
     const stored = this.#subscriptions.get(client.id)
 
     if (stored) {
-      for (const topicAndQos of stored) {
-        if (topicAndQos[1] > 0) {
-          const topic = topicAndQos[0]
+      for (const [topic, storedSub] of stored) {
+        if (storedSub.qos > 0) {
           trie.remove(topic, { clientId: client.id, topic })
         }
       }


### PR DESCRIPTION
Hi,

I am working on fixing Aedes bridge connection where `nl` flag is not respected:

https://github.com/moscajs/aedes/issues/736

For that I need to update `aedes-persistence` to persist `nl`, `rap` and `rh` flags.

The tests are still failing because `qlobber` also needs to be updated to work with `nl`, `rap` and `rh` flags:

https://github.com/davedoesdev/qlobber/pull/24

So this pull request needs to wait until qlobber is updated. 👍