### PR TITLE
fix: remove optional chaining usage to prevent Node.js 14 incompatibility

### DIFF
--- a/persistence.js
+++ b/persistence.js
@@ -110,7 +110,7 @@ class MemoryPersistence {
           rap: sub.rap,
           nl: sub.nl
         })
-      } else if (storedSub?.qos > 0) {
+      } else if (storedSub && storedSub.qos > 0) {
         trie.remove(sub.topic, {
           clientId: client.id,
           topic: sub.topic


### PR DESCRIPTION
# Why?
Using optional chaining operator break the Node.js 14 compatibility. I didn't found any changelog mentioning this in the last releases so I deduced that it was a small oversight. 
