### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, '*']
+        node-version: ['lts/-1', 'lts/*', 'node']
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,1 @@
+module.exports = require('neostandard')({})

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "main": "persistence.js",
   "types": "types/index.d.ts",
   "scripts": {
-    "lint": "standard --verbose | snazzy",
-    "lint-fix": "standard --fix",
+    "lint": "eslint",
+    "lint-fix": "eslint --fix",
     "unit": "tape test.js | faucet",
     "test:typescript": "tsd",
     "test": "npm run lint && npm run unit && tsd",
@@ -60,21 +60,21 @@
     "node": ">=14"
   },
   "devDependencies": {
-    "@types/node": "^17.0.29",
-    "aedes": "^0.46.3",
-    "faucet": "0.0.1",
+    "@fastify/pre-commit": "^2.2.0",
+    "@types/node": "^22.13.5",
+    "aedes": "^0.51.3",
+    "eslint": "^9.21.0",
+    "faucet": "^0.0.4",
     "license-checker": "^25.0.1",
-    "mqemitter": "^4.5.0",
-    "nyc": "^15.1.0",
-    "pre-commit": "^1.2.2",
-    "release-it": "^14.14.2",
-    "snazzy": "^9.0.0",
-    "standard": "^17.0.0",
-    "tape": "^5.5.3",
-    "tsd": "^0.20.0"
+    "mqemitter": "^6.0.2",
+    "neostandard": "^0.12.1",
+    "nyc": "^17.1.0",
+    "release-it": "^18.1.2",
+    "tape": "^5.9.0",
+    "tsd": "^0.31.2"
   },
   "dependencies": {
     "aedes-packet": "^3.0.0",
-    "qlobber": "^7.0.0"
+    "qlobber": "^8.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "types": "types/index.d.ts",
   "scripts": {
     "lint": "eslint",
-    "lint-fix": "eslint --fix",
-    "unit": "tape test.js | faucet",
+    "lint:fix": "eslint --fix",
+    "unit": "node --test test.js",
     "test:typescript": "tsd",
     "test": "npm run lint && npm run unit && tsd",
-    "coverage": "nyc --reporter=lcov tape test.js",
+    "coverage": "nyc --reporter=lcov node --test test.js",
     "test:ci": "npm run lint && npm run coverage && npm run test:typescript",
     "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'",
     "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
@@ -57,20 +57,18 @@
   },
   "homepage": "https://github.com/moscajs/aedes-persistence#readme",
   "engines": {
-    "node": ">=14"
+    "node": ">=20"
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.2.0",
     "@types/node": "^22.13.5",
     "aedes": "^0.51.3",
     "eslint": "^9.21.0",
-    "faucet": "^0.0.4",
     "license-checker": "^25.0.1",
     "mqemitter": "^6.0.2",
     "neostandard": "^0.12.1",
     "nyc": "^17.1.0",
     "release-it": "^18.1.2",
-    "tape": "^5.9.0",
     "tsd": "^0.31.2"
   },
   "dependencies": {

--- a/test.js
+++ b/test.js
@@ -1,6 +1,4 @@
-'use strict'
-
-const test = require('tape').test
+const test = require('node:test')
 const memory = require('./')
 const abs = require('./abstract')
 


### PR DESCRIPTION
This PR:
-  updates CI to use recent node versions
-  replaces `standard` by `eslint` with `neostandard`
-  replaces `pre-commit` by `@fastify/pre-commit`
-  replace `tape` and `faucet` by `node:test` 
-  upgrades all other dependencies to their latest versions

Kind regards,
Hans
