### PR TITLE
fix: add waitForReady to asyncMemory test

### DIFF
--- a/test.js
+++ b/test.js
@@ -25,5 +25,6 @@ function createAsyncMemory (opts) {
 
 abs({
   test,
-  persistence: createAsyncMemory
+  persistence: createAsyncMemory,
+  waitForReady: true
 })


### PR DESCRIPTION
as discussed in #95 this PR adds 'waitForReady:true` to the asyncMemory test.