### PR TITLE
fix:  fix waitForReady

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -310,13 +310,16 @@ function abstractPersistence (opts) {
 
     const instance = await _persistence()
     if (instance) {
+      // instance.broker must be set first because setting it triggers
+      // the call of instance._setup if aedes-cached-persistence is being used
+      // instance._setup then fires the 'ready'event
+      instance.broker = broker
       // Wait for ready event, if applicable, to ensure the persistence isn't
       // destroyed while it's still being set up.
       // https://github.com/mcollina/aedes-persistence-redis/issues/41
       if (waitForReady) {
         await waitForEvent(instance, 'ready')
       }
-      instance.broker = broker
       t.diagnostic('instance created')
       return instance
     }


### PR DESCRIPTION
This PR fixes a bug that I found whlle working on `aedes-persistence-mongodb`. I learned that when using `aedes-cached-persistence` (which builds on `aedes-persistense`) calls the  `_setup` method of the persistence as soon as `instance.broker`  is set. And as `_setup` emits the `ready` event, waiting for this event in `abstract.js` can only happen after setting `instance.broker` or else the wait will be forever.

This only touches `abstract.js` which is only used during testing of the various persistences.

Kind regards,
Hans
