### PR TITLE
fix: skip waiting for ready when instance is already ready

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -317,7 +317,7 @@ function abstractPersistence (opts) {
       // Wait for ready event, if applicable, to ensure the persistence isn't
       // destroyed while it's still being set up.
       // https://github.com/mcollina/aedes-persistence-redis/issues/41
-      if (waitForReady) {
+      if (waitForReady && !instance.ready) {
         await waitForEvent(instance, 'ready')
       }
       t.diagnostic('instance created')


### PR DESCRIPTION
This fixes the race condition where the instance is already ready and won't emit a ready event anymore.
As found in https://github.com/moscajs/aedes-persistence-mongodb/pull/83

Kind regards,
Hans