### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "unit": "node --test test.js",
     "test:typescript": "tsd",
     "test": "npm run lint && npm run unit && tsd",
-    "coverage": "nyc --reporter=lcov node --test test.js",
+    "coverage": "c8 --reporter=lcov node --test test.js",
     "test:ci": "npm run lint && npm run coverage && npm run test:typescript",
     "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'",
     "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
@@ -61,15 +61,15 @@
   },
   "devDependencies": {
     "@fastify/pre-commit": "^2.2.0",
-    "@types/node": "^22.13.5",
+    "@types/node": "^22.15.1",
     "aedes": "^0.51.3",
-    "eslint": "^9.21.0",
+    "c8": "^10.1.3",
+    "eslint": "^9.25.1",
     "license-checker": "^25.0.1",
-    "mqemitter": "^6.0.2",
+    "mqemitter": "^7.0.0",
     "neostandard": "^0.12.1",
-    "nyc": "^17.1.0",
-    "release-it": "^18.1.2",
-    "tsd": "^0.31.2"
+    "release-it": "^19.0.1",
+    "tsd": "^0.32.0"
   },
   "dependencies": {
     "aedes-packet": "^3.0.0",


### PR DESCRIPTION
This PR updates:
 @types/node  ^22.13.5  →  ^22.15.1
 eslint        ^9.21.0  →   ^9.25.1
 mqemitter      ^6.0.2  →    ^7.0.0
 release-it    ^18.1.2  →   ^19.0.1
 tsd           ^0.31.2  →   ^0.32.0

It also replaces nyc by c8

Kind regards,
Hans