### PR TITLE
feat: add additional retained match patterns with multiple wildcards to abstract.js

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -142,6 +142,11 @@ function abstractPersistence (opts) {
     await matchRetainedWithPattern(t, ['hello/+', 'other/hello'])
   })
 
+  test('look up retained messages with multiple wildcard patterns', async t => {
+    t.plan(1)
+    await matchRetainedWithPattern(t, ['hello/+', 'hel/#', 'hello/world/there/+'])
+  })
+
   test('store multiple retained messages in order', async (t) => {
     t.plan(1000)
     const prInstance = await persistence(t)

--- a/abstract.js
+++ b/abstract.js
@@ -85,9 +85,9 @@ function abstractPersistence (opts) {
     throw new Error('no instance')
   }
 
-  async function matchRetainedWithPattern (t, pattern) {
+  async function matchRetainedWithPattern (t, pattern, opts) {
     const prInstance = await persistence(t)
-    const packet = await storeRetainedPacket(prInstance)
+    const packet = await storeRetainedPacket(prInstance, opts)
     let stream
     if (Array.isArray(pattern)) {
       stream = prInstance.createRetainedStreamCombi(pattern)
@@ -120,6 +120,21 @@ function abstractPersistence (opts) {
   test('look up retained messages with a + pattern', async t => {
     t.plan(1)
     await matchRetainedWithPattern(t, 'hello/+')
+  })
+
+  test('look up retained messages with a + as first element', async t => {
+    t.plan(1)
+    await matchRetainedWithPattern(t, '+/world')
+  })
+
+  test('look up retained messages with +/#', async t => {
+    t.plan(1)
+    await matchRetainedWithPattern(t, '+/#')
+  })
+
+  test('look up retained messages with a + and # pattern with some in between', async t => {
+    t.plan(1)
+    await matchRetainedWithPattern(t, 'hello/+/world/#', { topic: 'hello/there/world/creatures' })
   })
 
   test('look up retained messages with multiple patterns', async t => {


### PR DESCRIPTION
This PR adds additional patterns with multiple wildcards to match on retained messages to the test suite in abstract.js
It aims to prevent regressions on https://github.com/moscajs/aedes-persistence-redis/pull/123

Kind regards,
Hans