### PR TITLE
fix: make setup() in callBackPersistence async

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -173,6 +173,12 @@ function abstractPersistence (opts) {
   }
 
   // testing starts here
+  test('verify setup() method is async', async t => {
+    t.plan(1)
+    const prInstance = await persistence(t)
+    t.assert.equal(prInstance.setup.constructor.name, 'AsyncFunction', '.setup() must be an async function')
+  })
+
   test('store and look up retained messages', async t => {
     t.plan(1)
     await matchRetainedWithPattern(t, 'hello/world')

--- a/callBackPersistence.js
+++ b/callBackPersistence.js
@@ -31,7 +31,7 @@ class CallBackPersistence extends EventEmitter {
       })
   }
 
-  setup (broker) {
+  async setup (broker) {
     return this.asyncPersistence.setup(broker)
   }
 

--- a/callBackPersistence.js
+++ b/callBackPersistence.js
@@ -17,10 +17,6 @@ class CallBackPersistence extends EventEmitter {
   }
 
   set broker (broker) {
-    this.setup(broker)
-  }
-
-  setup (broker) {
     if (this.ready) {
       return
     }
@@ -33,6 +29,10 @@ class CallBackPersistence extends EventEmitter {
       .catch(err => {
         this.emit('error', err)
       })
+  }
+
+  setup (broker) {
+    return this.asyncPersistence.setup(broker)
   }
 
   subscriptionsByTopic (topic, cb) {


### PR DESCRIPTION
while migrating aedes to async persistence I noticed that the `setup()` call in callback persistence did not return a promise.
This PR fixes that.

Kind regards,
Hans