### PR TITLE
fix: missing doCleanup in setup test

### DIFF
--- a/abstract.js
+++ b/abstract.js
@@ -177,6 +177,7 @@ function abstractPersistence (opts) {
     t.plan(1)
     const prInstance = await persistence(t)
     t.assert.equal(prInstance.setup.constructor.name, 'AsyncFunction', '.setup() must be an async function')
+    await doCleanup(t, prInstance)
   })
 
   test('store and look up retained messages', async t => {


### PR DESCRIPTION
THis PR fixes the missing `doCleanup` in abstract testing which caused testing not to end in:
- aedes-persistence-redis
- aedes-persistence-mongodb

The fixed version has been tested with both modules and solves the problem.

Kind regards,
Hans